### PR TITLE
Image import fix and tags import enhancement

### DIFF
--- a/api/image/base/api_views.py
+++ b/api/image/base/api_views.py
@@ -231,8 +231,9 @@ class ImageView(TaskAPIView):
         img.alias = img.name        # Default alias (can be changed)
         img.status = Image.OK       # Set status for preliminary checks
 
-        for img_field in ('version', 'desc'):  # More default fields retrieved from the downloaded image manifest
-            if not data.get(img_field, None):
+        # More default fields retrieved from the downloaded image manifest
+        for img_field in ('version', 'desc', 'resize', 'deploy', 'tags'):
+            if img_field not in data:
                 def_value = getattr(img, img_field, None)
                 if def_value:
                     data[img_field] = def_value

--- a/api/image/base/serializers.py
+++ b/api/image/base/serializers.py
@@ -142,6 +142,10 @@ class ImportImageSerializer(s.Serializer):
             img.ostype = Image.os_to_ostype(manifest)
             img.size = int(manifest.get('image_size', Image.DEFAULT_SIZE))
             img.desc = manifest.get('description', '')[:128]
+            tags = manifest.pop('tags', {})
+            img.tags = tags.get(Image.TAGS_KEY, [])
+            img.deploy = tags.get('deploy', False)
+            img.resize = tags.get('resize', img.ostype in img.ZONE)
         except Exception:
             raise s.ValidationError(_('Invalid image manifest.'))
 

--- a/api/image/base/views.py
+++ b/api/image/base/views.py
@@ -88,11 +88,12 @@ def image_manage(request, name, data=None):
         :arg data.version: Image version (default: read from manifest)
         :type data.version: string
         :arg data.resize: Whether the image is able to resize the disk during an initial start or deploy process \
-(default: false)
+(default: read from manifest / true for OS zones, otherwise false)
         :type data.resize: boolean
-        :arg data.deploy: Whether the image is able to shut down the server after an initial start (default: false)
+        :arg data.deploy: Whether the image is able to shut down the server after an initial start \
+(default: read from manifest / false)
         :type data.deploy: boolean
-        :arg data.tags: Image tags will be inherited by VMs which will use this image (default: [])
+        :arg data.tags: Image tags will be inherited by VMs which will use this image (default: read from manifest)
         :type data.tags: array
         :arg data.dc_bound: Whether the disk image is bound to a datacenter (requires |SuperAdmin| permission) \
 (default: true)

--- a/api/imagestore/image/api_views.py
+++ b/api/imagestore/image/api_views.py
@@ -51,7 +51,7 @@ class ImageStoreImageView(APIView):
     def post(self):
         img = self.get_image()
         data = self.data
-        data['manifest_url'] = self.repo.get_image_manifes_url(img['uuid'])
+        data['manifest_url'] = self.repo.get_image_manifest_url(img['uuid'])
         data.pop('file_url', None)
         name = data.get('name', None)
 

--- a/api/system/init.py
+++ b/api/system/init.py
@@ -66,7 +66,7 @@ def _init_images(images, default_dc, admin_dc):
             img.desc = manifest.get('desc', '')[:128]
             img.status = Image.OK
             img.manifest = img.manifest_active = manifest
-            tags = manifest.get('tags', {})
+            tags = manifest.pop('tags', {})
             img.tags = tags.get(Image.TAGS_KEY, [])
             img.deploy = tags.get('deploy', False)
             img.resize = tags.get('resize', img.ostype in img.ZONE)

--- a/api/system/init.py
+++ b/api/system/init.py
@@ -62,8 +62,8 @@ def _init_images(images, default_dc, admin_dc):
             img.name = img.alias = manifest['name']
             img.version = manifest['version']
             img.ostype = Image.os_to_ostype(manifest)
-            img.size = int(manifest.get('image_size', 1024))
-            img.desc = manifest.get('desc', '')[:128]
+            img.size = int(manifest.get('image_size', Image.DEFAULT_SIZE))
+            img.desc = manifest.get('description', '')[:128]
             img.status = Image.OK
             img.manifest = img.manifest_active = manifest
             tags = manifest.pop('tags', {})

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 #########
 
+
+2.3.1 (unreleased)
+========================================
+
+Features
+--------
+
+
+Bugs
+----
+
+- Fixed ``KeyError: 'get_image_manifes_url'`` error during POST imagestore_image_manage - `#8 <https://github.com/erigones/esdc-ce/issues/8>`__
+
+
+
 2.3.0 (released on 2016-11-14)
 ========================================
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Bugs
 ----
 
 - Fixed ``KeyError: 'get_image_manifes_url'`` error during POST imagestore_image_manage - `#8 <https://github.com/erigones/esdc-ce/issues/8>`__
+- Added support for Danube Cloud (erigones) image tags into POST image_manage - `#7 <https://github.com/erigones/esdc-ce/issues/7>`__
 
 
 

--- a/vms/models/image.py
+++ b/vms/models/image.py
@@ -227,7 +227,13 @@ class Image(_VirtModel, _JsonPickleModel, _OSType, _DcMixin, _UserTasksModel):
 
         if u'tags' not in manifest:
             manifest[u'tags'] = {}
-        manifest[u'tags'][self.TAGS_KEY] = self.tags
+
+        manifest[u'tags'].update({
+            self.TAGS_KEY: self.tags,
+            'resize': self.resize,
+            'deploy': self.deploy,
+            'internal': self.access == self.INTERNAL,
+        })
 
         if self.ostype in self.ZONE:
             for i in ('image_size', 'nic_driver', 'disk_driver', 'cpu_type'):

--- a/vms/models/imagestore.py
+++ b/vms/models/imagestore.py
@@ -46,12 +46,17 @@ class ImageStoreObject(dict):
     def web_data(self):
         """Return dict used in web templates"""
         manifest = self['manifest']
+        tags = manifest.get('tags', {})
+
         return {
             'name': manifest['name'],
             'alias': manifest['name'],
             'version': manifest['version'],
             'desc': manifest.get('description', '')[:128],
             'dc_bound': False,
+            'tags': tags.get(Image.TAGS_KEY, []),
+            'deploy': tags.get('deploy', False),
+            'resize': tags.get('resize', self['ostype'] in Image.ZONE),
             'manifest_url': self['manifest_url'],
         }
 


### PR DESCRIPTION
- Fixed ``KeyError: 'get_image_manifes_url'`` error during POST imagestore_image_manage - #8 
- Added support for Danube Cloud (erigones) image tags into POST image_manage - #7 

I originally thought that this is a bug in esdc-factory - erigones/esdc-factory#6