### PR TITLE
Added ctl.sh compile command and running it during ctl.sh deploy

### DIFF
--- a/core/management/commands/build.py
+++ b/core/management/commands/build.py
@@ -19,6 +19,7 @@ class Command(DanubeCloudCommand):
             raise CommandError('Running on compute node, did you forget to specify "--node"?')
 
         ctlsh(*pip_install)
+        ctlsh('compile')
 
         if not que_only:
             ctlsh('patch_envs')

--- a/core/management/commands/compile.py
+++ b/core/management/commands/compile.py
@@ -1,0 +1,15 @@
+from compileall import compile_dir
+
+from ._base import DanubeCloudCommand
+
+
+class Command(DanubeCloudCommand):
+    help = 'Recursively byte=compile all modules in ERIGONES_HOME.'
+
+    def handle(self, *args, **options):
+        rc = compile_dir(self.PROJECT_DIR, maxlevels=20, quiet=int(not self.verbose))
+
+        if rc == 0:
+            self.display('Byte-compiled all modules in %s' % self.PROJECT_DIR, color='green')
+        else:
+            self.display('Error while byte-compiling some modules in %s' % self.PROJECT_DIR, color='red')

--- a/core/management/commands/compile.py
+++ b/core/management/commands/compile.py
@@ -7,7 +7,9 @@ class Command(DanubeCloudCommand):
     help = 'Recursively byte=compile all modules in ERIGONES_HOME.'
 
     def handle(self, *args, **options):
-        rc = compile_dir(self.PROJECT_DIR, maxlevels=20, quiet=int(not self.verbose))
+        self.display('Byte-compiling all modules in %s' % self.PROJECT_DIR, color='white')
+        quiet = int(int(options.get('verbosity', self.default_verbosity)) <= self.default_verbosity)
+        rc = compile_dir(self.PROJECT_DIR, maxlevels=20, quiet=quiet)
 
         if rc == 0:
             self.display('Byte-compiled all modules in %s' % self.PROJECT_DIR, color='green')

--- a/core/version.py
+++ b/core/version.py
@@ -1,2 +1,2 @@
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 __edition__ = 'ce'

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,19 @@ Changelog
 #########
 
 
+2.3.3 (unreleased)
+========================================
+
+Features
+--------
+
+Bugs
+----
+
+- Fixed permission problems during byte-compilation of modules in production - `#28 <https://github.com/erigones/esdc-ce/issues/28>`__
+
+
+
 2.3.2 (released on 2016-12-17)
 ========================================
 


### PR DESCRIPTION
@secult has raised a problem about permissions of byte-compiled modules (.pyc) in ERIGONES_HOME in production. The source and compiled files are owned by root, but are accessed by processes that run under the erigones user. After an upgrade of source files the pyc files are not updated, because the services do not have permissions to re-compile the bytecode.