### PR TITLE
Security fix handling str.format() insecurity issue

### DIFF
--- a/api/dc/base/serializers.py
+++ b/api/dc/base/serializers.py
@@ -7,7 +7,7 @@ from core.external.decorators import (
     third_party_apps_dc_modules_and_settings, third_party_apps_default_dc_modules_and_settings
 )
 from api import serializers as s
-from api.validators import validate_owner, validate_alias, validate_mdata, validate_ssh_key
+from api.validators import validate_owner, validate_alias, validate_mdata, validate_ssh_key, placeholder_validator
 from api.vm.utils import get_owners
 from api.sms.utils import get_services
 from api.mon.zabbix import VM_KWARGS, VM_KWARGS_NIC, VM_KWARGS_DISK
@@ -19,14 +19,6 @@ from pdns.models import Domain
 
 SENSITIVE_FIELD_NAMES = ('PASSWORD', 'PRIVATE_KEY')
 SENSITIVE_FIELD_VALUE = '***'
-
-
-def placeholder_validator(value, **valid_placeholders):
-    """Helper for checking if the value has acceptable placeholders"""
-    try:
-        return value.format(**valid_placeholders)
-    except (KeyError, ValueError, TypeError):
-        raise s.ValidationError(_('Invalid placeholders.'))
 
 
 def validate_array_placeholders(attrs, source, valid_placeholders):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Bugs
 
 - Fixed permission problems during byte-compilation of modules in production - `#28 <https://github.com/erigones/esdc-ce/issues/28>`__
 - Fixed validation of MON_ZABBIX_TEMPLATES_VM_NIC and MON_ZABBIX_TEMPLATES_VM_DISK DC settings - `#31 <https://github.com/erigones/esdc-ce/issues/31>`__
+- Fixed validation of placeholders supported in DC Settings - `#34 <https://github.com/erigones/esdc-ce/issues/34>`__
 
 
 2.3.2 (released on 2016-12-17)


### PR DESCRIPTION
As described in issue #34  the str.format() has problem which could potentially expose internal variables to the world.  
This fix makes sure that placeholders match exactly those allowed by us.