### PR TITLE
Expose node, network and image UUIDs via API

### DIFF
--- a/api/image/base/serializers.py
+++ b/api/image/base/serializers.py
@@ -19,6 +19,7 @@ class ImageSerializer(s.InstanceSerializer):
     _default_fields_ = ('name', 'alias', 'owner')
 
     name = s.RegexField(r'^[A-Za-z0-9][A-Za-z0-9\._-]*$', max_length=32)
+    uuid = s.CharField(read_only=True)
     alias = s.SafeCharField(max_length=32)
     version = s.SafeCharField(max_length=16, default='1.0')
     owner = s.SlugRelatedField(slug_field='username', queryset=User.objects)

--- a/api/network/base/serializers.py
+++ b/api/network/base/serializers.py
@@ -23,6 +23,7 @@ class NetworkSerializer(s.InstanceSerializer):
 
     # min_length because of API URL: /network/ip/
     name = s.RegexField(r'^[A-Za-z0-9][A-Za-z0-9\._-]*$', min_length=3, max_length=32)
+    uuid = s.CharField(read_only=True)
     alias = s.SafeCharField(max_length=32)
     owner = s.SlugRelatedField(slug_field='username', queryset=User.objects, required=False)
     access = s.IntegerChoiceField(choices=Subnet.ACCESS, default=Subnet.PRIVATE)

--- a/api/node/define/serializers.py
+++ b/api/node/define/serializers.py
@@ -18,9 +18,9 @@ class NodeDefineSerializer(s.InstanceSerializer):
     _update_fields_ = ('status', 'owner', 'is_compute', 'is_backup', 'cpu_coef', 'ram_coef',
                        'monitoring_hostgroups', 'monitoring_templates')
 
-    hostname = s.Field()
-    uuid = s.Field()
-    address = s.Field()
+    hostname = s.CharField(read_only=True)
+    uuid = s.CharField(read_only=True)
+    address = s.CharField(read_only=True)
     status = s.IntegerChoiceField(choices=Node.STATUS_DB)
     node_status = s.DisplayChoiceField(source='status', choices=Node.STATUS_DB, read_only=True)
     owner = s.SlugRelatedField(slug_field='username', queryset=User.objects, read_only=False)
@@ -34,7 +34,7 @@ class NodeDefineSerializer(s.InstanceSerializer):
     cpu_free = s.IntegerField(read_only=True)
     ram_free = s.IntegerField(read_only=True)
     ram_kvm_overhead = s.IntegerField(read_only=True)
-    sysinfo = s.Field(source='api_sysinfo')
+    sysinfo = s.Field(source='api_sysinfo')  # Field is read_only=True by default
     monitoring_hostgroups = s.ArrayField(max_items=16, default=[])
     monitoring_templates = s.ArrayField(max_items=32, default=[])
     created = s.DateTimeField(read_only=True, required=False)

--- a/api/node/define/serializers.py
+++ b/api/node/define/serializers.py
@@ -19,6 +19,7 @@ class NodeDefineSerializer(s.InstanceSerializer):
                        'monitoring_hostgroups', 'monitoring_templates')
 
     hostname = s.Field()
+    uuid = s.Field()
     address = s.Field()
     status = s.IntegerChoiceField(choices=Node.STATUS_DB)
     node_status = s.DisplayChoiceField(source='status', choices=Node.STATUS_DB, read_only=True)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,7 @@ Features
 - Backup restore and snapshot restore accept VM UUID besides hostname as a parameter - `#26 <https://github.com/erigones/esdc-ce/issues/26>`__
 - Backup restore API call has no default target vm and disk anymore, which makes the call less error-prone - `#26 <https://github.com/erigones/esdc-ce/issues/26>`__
 - Implemented task retries after operational errors (mgmt callbacks) - `#38 <https://github.com/erigones/esdc-ce/issues/38>`__
+- Exposed compute node, network and image UUIDs via API - `#49 <https://github.com/erigones/esdc-ce/issues/49>`__
 
 
 Bugs


### PR DESCRIPTION
The user should be able to find out UUIDs of compute nodes, images and networks in Danube Cloud.