### PR TITLE
Removed DB object caching between GUI<->API internal requests

### DIFF
--- a/api/node/utils.py
+++ b/api/node/utils.py
@@ -6,11 +6,6 @@ def get_node(request, hostname, attrs=None, where=None, exists_ok=True, noexists
              dc=False, api=True, extra=None, annotate=None):
     """Call get_object for Node model identified by hostname.
     This function should be called by staff users or DC admins only."""
-    # Quickly return node, if set in request (shortcut from GUI)
-    node = getattr(request, '_api_node', None)
-    if api and node:
-        return node
-
     if attrs is None:
         attrs = {}
 

--- a/api/vm/utils.py
+++ b/api/vm/utils.py
@@ -17,11 +17,6 @@ def get_vm(request, hostname, attrs=None, where=None, exists_ok=False, noexists_
     specified then set them to check owner and node status.
     Also acts as IsVmOwner permission.
     """
-    # Quickly return vm, if set in request (shortcut from GUI)
-    vm = getattr(request, '_api_vm', None)
-    if api and vm:
-        return vm
-
     if where is None:
         where = QNodeNullOrLicensed
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,7 @@ Bugs
 - Fixed validation of MON_ZABBIX_TEMPLATES_VM_NIC and MON_ZABBIX_TEMPLATES_VM_DISK DC settings - `#31 <https://github.com/erigones/esdc-ce/issues/31>`__
 - Fixed validation of placeholders supported in DC Settings - `#34 <https://github.com/erigones/esdc-ce/issues/34>`__
 - Fixed update script to call its NEW self - `#44 <https://github.com/erigones/esdc-ce/issues/44>`__
+- Removed DB object caching between GUI<->API internal requests - `#62 <https://github.com/erigones/esdc-ce/issues/62>`__
 
 
 2.3.2 (released on 2016-12-17)

--- a/gui/vm/forms.py
+++ b/gui/vm/forms.py
@@ -10,7 +10,7 @@ import re
 from pdns.models import Record
 from vms.models import Vm, Snapshot, Backup, BackupDefine
 from vms.utils import AttrDict
-from gui.forms import SerializerForm as _SerializerForm
+from gui.forms import SerializerForm
 from gui.utils import tags_to_string
 from gui.fields import ArrayField, DictField, TagField
 from gui.widgets import NumberInput, ArrayWidget, DictWidget, TagWidget
@@ -82,23 +82,6 @@ class HostnameForm(forms.Form):
     hostname = forms.CharField(label=_('Hostname'), required=True,
                                widget=forms.TextInput(attrs={'class': 'input-transparent narrow uneditable-input',
                                                              'disabled': 'disabled'}))
-
-
-class SerializerForm(_SerializerForm):
-    """
-    Just override api_call() -> will save one DB call.
-    """
-    @classmethod
-    def api_call(cls, action, obj, request, **kwargs):
-        # Set vm object to request and get_vm in api will skip a DB call
-        request._api_vm = obj
-
-        res = super(SerializerForm, cls).api_call(action, obj, request, **kwargs)
-
-        # Remove vm, because request could be re-used somewhere
-        request._api_vm = None
-
-        return res
 
 
 class ServerSettingsForm(SerializerForm):


### PR DESCRIPTION
The `get_vm()` in API had one additional check (node status) that was bypassed by some requests made via GUI (e.g. a backup definition could be removed while a compute node was not available).
The shortcut in `get_node()` was not used.