### PR TITLE
Fixed DNS permission checking for DC-bound domains

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,7 @@ Bugs
 - Fixed validation of MON_ZABBIX_TEMPLATES_VM_NIC and MON_ZABBIX_TEMPLATES_VM_DISK DC settings - `#31 <https://github.com/erigones/esdc-ce/issues/31>`__
 - Fixed validation of placeholders supported in DC Settings - `#34 <https://github.com/erigones/esdc-ce/issues/34>`__
 - Fixed update script to call its NEW self - `#44 <https://github.com/erigones/esdc-ce/issues/44>`__
+- Fixed DNS permission checking for DC-bound domains - `#63 <https://github.com/erigones/esdc-ce/issues/63>`__
 
 
 2.3.2 (released on 2016-12-17)

--- a/gui/dc/dns/forms.py
+++ b/gui/dc/dns/forms.py
@@ -113,9 +113,9 @@ class DnsRecordFilterForm(forms.Form):
             domain_choices = [(d.name, d.name) for d in domains]
         else:
             dc_domain_ids = list(dc.domaindc_set.values_list('domain_id', flat=True))
-            domains = domains.filter(id__in=dc_domain_ids)
+            domains = domains.filter(Q(id__in=dc_domain_ids) | Q(user=user.id))
             domain_choices = [(d.name, d.name) for d in domains
-                              if (user.is_staff or d.owner == user or d.dc_bound == dc.id)]
+                              if (user.is_staff or d.user == user.id or d.dc_bound == dc.id)]
 
         self.fields['domain'].choices = domain_choices
 

--- a/gui/dc/dns/utils.py
+++ b/gui/dc/dns/utils.py
@@ -17,8 +17,5 @@ def get_domain(request, name):
         domain = qs.get(name=name)
     except Domain.DoesNotExist:
         raise Http404
-    else:
-        # Shortcut for repeated get_domain() call in API
-        request._api_domain = domain
 
     return domain


### PR DESCRIPTION
The permission system for DC-bound Domains was broken in the API. It worked in the GUI because the Domain object was cached and some checks were bypassed in `get_domain()` in the API.

In addition to the *DnsAdmin* permission, Domains also support a *DomainOwner* permission, which makes things even more complicated. The following PR should fix all problems and the behavior should be similar to other DC-related objects. All permission checks should work from the API. The *DomainOwner* permission is not supported from the GUI.