### PR TITLE
Fix tasklog filter (API & GUI) and pager (API)

### DIFF
--- a/api/fields.py
+++ b/api/fields.py
@@ -330,7 +330,7 @@ class WritableField(Field):
 
     # noinspection PyShadowingNames
     def __init__(self, source=None, label=None, help_text=None, read_only=False, write_only=False, required=None,
-                 validators=(), error_messages=None, default=None, allow_empty=None):
+                 validators=(), error_messages=None, default=None, allow_empty=None, **kwargs):
         super(WritableField, self).__init__(source=source, label=label, help_text=help_text)
 
         self.read_only = read_only

--- a/api/paginator.py
+++ b/api/paginator.py
@@ -15,32 +15,32 @@ class Paginator(DjangoPaginator):
 
     def __init__(self, request, object_list, per_page, **kwargs):
         super(Paginator, self).__init__(object_list, per_page, **kwargs)
-        self.page = None
+        self._page = None
         self.request = request
 
     def get_page(self, page):
         try:
-            self.page = self.page(page)
+            self._page = self.page(page)
         except InvalidPage:
             raise NotFound(self.invalid_page_message)
         else:
-            return self.page
+            return self._page
 
     def get_next_link(self):
-        if not self.page.has_next():
+        if not self._page.has_next():
             return None
 
         url = self.request.build_absolute_uri()
-        page_number = self.page.next_page_number()
+        page_number = self._page.next_page_number()
 
         return replace_query_param(url, self.page_query_param, page_number)
 
     def get_previous_link(self):
-        if not self.page.has_previous():
+        if not self._page.has_previous():
             return None
 
         url = self.request.build_absolute_uri()
-        page_number = self.page.previous_page_number()
+        page_number = self._page.previous_page_number()
 
         if page_number == 1:
             return None
@@ -49,7 +49,7 @@ class Paginator(DjangoPaginator):
 
     def get_response_results(self, results):
         return OrderedDict([
-            ('count', self.page.paginator.count),
+            ('count', self._page.paginator.count),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
             ('results', results),

--- a/api/task/serializers.py
+++ b/api/task/serializers.py
@@ -109,7 +109,7 @@ class TaskLogFilterSerializer(s.Serializer):
         if data.get('show_running'):
             query.append(Q(task__in=pending_tasks))
 
-        object_type = data.get('object_type')
+        object_type = data.get('content_type')
         if object_type:
             if self._content_type:
                 content_type = self._content_type

--- a/api/task/task_log.py
+++ b/api/task/task_log.py
@@ -32,7 +32,7 @@ class TaskLogView(APIView):
             tasklog_items = get_tasklog(request, q=q, order_by=self.order_by)
             TaskLogEntry.prepare_queryset(tasklog_items)
             pag = get_pager(request, tasklog_items, per_page=100)
-            res = pag.paginator.get_response_results(TaskLogEntrySerializer(pag).data)
+            res = pag.paginator.get_response_results(TaskLogEntrySerializer(pag, many=True).data)
         else:
             res = {'results': get_tasklog_cached(request)}
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,8 @@ Bugs
 - Fixed redirect after VM hostname change - `#70 <https://github.com/erigones/esdc-ce/issues/70>`__
 - Fixed minor issues in Import/Export functionality - `#71 <https://github.com/erigones/esdc-ce/issues/71>`__
 - Fixed language switching in user profile - `#72 <https://github.com/erigones/esdc-ce/issues/72>`__
+- Fixed ``GET /task/log -page <number>`` API view - `#74 <https://github.com/erigones/esdc-ce/pull/74>`__
+- Fixed object_type filter in Task Log (API & GUI) - `#74 <https://github.com/erigones/esdc-ce/pull/74>`__
 
 
 2.3.3 (released on 2017-02-04)


### PR DESCRIPTION
The object_type filter is not working in both API and GUI. And the `GET /task/log -page <number>` throws an exception.