### PR TITLE
Removed Terms of Service acceptation checkbox when empty TOS_LINK setting

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Bugs
 ----
 
 - Fixed bug that assigned old IP address to the VM during the redeploy - `#77 <https://github.com/erigones/esdc-ce/issues/77>`__
+- Disabled TOS acceptation checkbox when TOS_LINK is empty - `#78 <https://github.com/erigones/esdc-ce/issues/78>`__
 
 
 2.4.0 (released on 2017-02-22)

--- a/gui/accounts/forms.py
+++ b/gui/accounts/forms.py
@@ -216,7 +216,7 @@ class UserProfileRegisterForm(forms.ModelForm):
     User profile registration form, for extended data collected about user (gui users table)
     """
     include_company = False
-    include_tos = True
+    include_tos = bool(settings.TOS_LINK)
     include_others = True
     phone_help_text = _('You will receive a text message with an auto-generated password which you can change after '
                         'login.')

--- a/gui/models/userprofile.py
+++ b/gui/models/userprofile.py
@@ -148,6 +148,7 @@ class UserProfile(models.Model):
                 (self.tos_acceptation or not settings.TOS_LINK) and
                 self.email_verified and
                 self.phone_verified and
+                # A company user account also requires a valid company ID
                 (self.usertype == self.PERSONAL or (self.usertype == self.COMPANY and self.companyid))
             )
         )

--- a/gui/models/userprofile.py
+++ b/gui/models/userprofile.py
@@ -145,7 +145,7 @@ class UserProfile(models.Model):
         return (
             self.user.email and self.phone and (
                 not settings.REGISTRATION_ENABLED or
-                self.tos_acceptation and
+                (self.tos_acceptation or not settings.TOS_LINK) and
                 self.email_verified and
                 self.phone_verified and
                 (self.usertype == self.PERSONAL or (self.usertype == self.COMPANY and self.companyid))

--- a/gui/profile/forms.py
+++ b/gui/profile/forms.py
@@ -249,7 +249,8 @@ class UserProfileForm(SerializerForm):
     def __init__(self, request, profile, *args, **kwargs):
         super(UserProfileForm, self).__init__(request, profile, *args, **kwargs)
 
-        # Display TOS acceptation checkbox if user did not accepted TOS and registration is enabled
+        # Do not display the TOS acceptation checkbox if user already accepted the TOS or TOS_LINK is not set or
+        # registration module is disabled
         if (profile.user.is_staff or profile.tos_acceptation or
                 not settings.REGISTRATION_ENABLED or not settings.TOS_LINK):
             del self.fields['tos_acceptation']

--- a/gui/profile/forms.py
+++ b/gui/profile/forms.py
@@ -250,7 +250,8 @@ class UserProfileForm(SerializerForm):
         super(UserProfileForm, self).__init__(request, profile, *args, **kwargs)
 
         # Display TOS acceptation checkbox if user did not accepted TOS and registration is enabled
-        if profile.user.is_staff or profile.tos_acceptation or not settings.REGISTRATION_ENABLED:
+        if (profile.user.is_staff or profile.tos_acceptation or
+                not settings.REGISTRATION_ENABLED or not settings.TOS_LINK):
             del self.fields['tos_acceptation']
 
         if not profile.user.is_staff and user_profile_company_only_form(profile.user):


### PR DESCRIPTION
The TOS checkbox does not make sense without a valid HTTP link to Terms of Service.