### PR TITLE
Updated versions of packages in requirements-*.txt files

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,7 +9,8 @@ Features
 
 - Added compute node monitoring and graphs to GUI and API - `#13 <https://github.com/erigones/esdc-ce/issues/13>`__
 - Added ``cpu_type`` parameter into vm_define API call - `#76 <https://github.com/erigones/esdc-ce/issues/76>`__
-- Updated metadata input fields to accept raw JSON input `#79 <https://github.com/erigones/esdc-ce/issues/79>`__
+- Updated metadata input fields to accept raw JSON input - `#79 <https://github.com/erigones/esdc-ce/issues/79>`__
+- Updated version of the packages in requirement files - `#81 <https://github.com/erigones/esdc-ce/issues/81>`__
 
 Bugs
 ----

--- a/etc/requirements-both.txt
+++ b/etc/requirements-both.txt
@@ -1,7 +1,7 @@
 ### que
-setuptools==28.6.1
+setuptools==34.3.0
 six==1.10.0
-psutil==4.4.2
+psutil==5.1.3
 celery==3.1.25
 billiard==3.3.0.23
 amqp==1.4.9

--- a/etc/requirements-mgmt.txt
+++ b/etc/requirements-mgmt.txt
@@ -1,13 +1,13 @@
 --find-links https://download.erigones.org/pypi/
 ### project
 pip
-setuptools==28.6.1
+setuptools==34.3.0
 Django==1.8.17
-Sphinx==1.4.8
-Jinja2==2.8
+Sphinx==1.5.3
+Jinja2==2.9.5
 sphinxcontrib-httpdomain==1.5.0
-Pygments==2.1.3
-docutils==0.12
+Pygments==2.2.0
+docutils==0.13.1
 
 ### dns
 dnspython==1.15.0
@@ -17,14 +17,14 @@ celery==3.1.25
 kombu==3.0.37
 pytz==2016.10
 ipaddress==1.0.18
-gevent==1.1.2
+gevent==1.2.1
 gevent-socketio-es==0.3.7
 gevent-websocket==0.9.5
 greenlet==0.4.12
 gunicorn==19.6.0
-Pillow==3.4.2
+Pillow==4.0.0
 xmltodict==0.10.2
-python-dateutil==2.5.3
+python-dateutil==2.6.0
 django-taggit==0.22.0
 django-celery==3.1.17
 cryptography==1.5.3
@@ -38,8 +38,8 @@ django-redis-cache==1.7.1
 hiredis==0.2.0
 wsgiref==0.1.2
 django-compressor==2.1.1
-phonenumbers==8.2.0
-django-timezone-field==1.3
+phonenumbers==8.3.1
+django-timezone-field==2.0
 blinker==1.4
-lxml==3.6.4
+lxml==3.7.0
 openpyxl==2.3.5


### PR DESCRIPTION
setuptools 28.6.1 -> 34.3.0
psutil  4.4.2 -> 5.1.3
Sphinx  1.4.8 -> 1.5.3
Jinja2  2.8 -> 2.9.5
Pygments  2.1.3 -> 2.2.0
docutils  0.12 -> 0.13.1
phonenumbers  8.2.0 -> 8.3.1
django-timezone-field  1.3 -> 2.0
gevent  1.1.2 -> 1.2.1
Pillow  3.4.2 -> 4.0.0
python-dateutil  2.5.3 -> 2.6.0
lxml  3.6.4 -> 3.7.0