### PR TITLE
Fixing race conditions during VM status change

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ Bugs
 - Fixed bug that assigned old IP address to the VM during the redeploy - `#77 <https://github.com/erigones/esdc-ce/issues/77>`__
 - Disabled TOS acceptation checkbox when TOS_LINK is empty - `#78 <https://github.com/erigones/esdc-ce/issues/78>`__
 - Fixed RAM/HDD size rounding in sample export spreadsheet - `#83 <https://github.com/erigones/esdc-ce/issues/83>`__
+- Fixed race conditions that could happen during VM status changes - `#85 <https://github.com/erigones/esdc-ce/issues/85>`__
 
 
 2.4.0 (released on 2017-02-22)

--- a/vms/models/vm.py
+++ b/vms/models/vm.py
@@ -1431,10 +1431,10 @@ class Vm(_StatusModel, _JsonPickleModel, _OSType, _UserTasksModel):
 
         return uptime
 
-    def save_zoneid(self, zoneid):
+    def save_zoneid(self, zoneid, change_time=None):
         """Save new zoneid"""
         cache.set(self.zoneid_key(self.uuid), zoneid)
-        cache.set(self.zoneid_change_key(self.uuid), timezone.now())
+        cache.set(self.zoneid_change_key(self.uuid), change_time or timezone.now())
 
     @staticmethod
     def zoneid_key(uuid):


### PR DESCRIPTION
Allowing to change VM status via a status event from CN during a running vm_status_task.
Changed time of status change in `vm_status_cb` to have an older value than a status event from CN
Fetching real status change times in automatic `vm_status_all` and `vm_status_one` tasks
This fixes several race conditions that can happen during VM status changes.