### PR TITLE
Fixed bug that caused node monitoring graphs not to show

### DIFF
--- a/api/mon/node/api_views.py
+++ b/api/mon/node/api_views.py
@@ -81,6 +81,7 @@ class NodeHistoryView(APIView):
             request, t_mon_node_history,
             view_fun_name='mon_node_history',
             obj=self.node,
+            dc_bound=False,
             serializer=ser,
             data=self.data,
             graph=graph,

--- a/api/mon/node/api_views.py
+++ b/api/mon/node/api_views.py
@@ -48,6 +48,8 @@ class NodeSLAView(APIView):
 
 class NodeHistoryView(APIView):
     """ """
+    dc_bound = False
+
     def __init__(self, request, hostname, graph_type, data):
         super(NodeHistoryView, self).__init__(request)
         self.node = get_node(request, hostname)

--- a/api/mon/utils.py
+++ b/api/mon/utils.py
@@ -75,7 +75,7 @@ def call_mon_history_task(request, task_function, view_fun_name, obj, dc_bound,
         tg = TG_DC_UNBOUND
 
     ter = task_function.call(request, obj.owner.id, (obj.uuid, items, history, result, items_search),
-                                 tg=tg, meta={'apiview': _apiview_}, tidlock=tidlock)
+                             tg=tg, meta={'apiview': _apiview_}, tidlock=tidlock)
     # NOTE: cache_result=tidlock, cache_timeout=60)
     # Caching is disable here, because it makes no real sense.
     # The latest graphs must be fetched from zabbix and the older are requested only seldom.

--- a/api/mon/utils.py
+++ b/api/mon/utils.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from api.task.internal import InternalTask
 from api.task.response import mgmt_task_response
 from vms.utils import AttrDict
+from que import TG_DC_UNBOUND
 
 
 class MonitoringGraph(AttrDict):
@@ -30,7 +31,8 @@ class MonInternalTask(InternalTask):
         return super(MonInternalTask, self).call(*args, **kwargs)
 
 
-def call_mon_history_task(request, task_function, view_fun_name, obj, serializer, data, graph, graph_settings):
+def call_mon_history_task(request, task_function, view_fun_name, obj, dc_bound,
+                          serializer, data, graph, graph_settings):
     """Function that calls task_function callback and returns output mgmt_task_response()"""
     _apiview_ = {
         'view': view_fun_name,
@@ -66,10 +68,16 @@ def call_mon_history_task(request, task_function, view_fun_name, obj, serializer
         items_search = None
 
     history = graph_settings['history']
-    ter = task_function.call(request, obj.owner.id, (obj.uuid, items, history, result, items_search),
-                             meta={'apiview': _apiview_}, tidlock=tidlock)
+    # for VM the task_function is called without task group value because it's DC bound
+    if dc_bound:
+        ter = task_function.call(request, obj.owner.id, (obj.uuid, items, history, result, items_search),
+                                 meta={'apiview': _apiview_}, tidlock=tidlock)
+    else:
+        ter = task_function.call(request, obj.owner.id, (obj.uuid, items, history, result, items_search),
+                                 tg=TG_DC_UNBOUND, meta={'apiview': _apiview_}, tidlock=tidlock)
     # NOTE: cache_result=tidlock, cache_timeout=60)
     # Caching is disable here, because it makes no real sense.
     # The latest graphs must be fetched from zabbix and the older are requested only seldom.
 
-    return mgmt_task_response(request, *ter, obj=obj, api_view=_apiview_, data=data)
+    return mgmt_task_response(request, *ter, obj=obj, api_view=_apiview_,
+                              dc_bound=dc_bound, data=data)

--- a/api/mon/vm/api_views.py
+++ b/api/mon/vm/api_views.py
@@ -131,6 +131,7 @@ class VmHistoryView(APIView):
             request, t_mon_vm_history,
             view_fun_name='mon_vm_history',
             obj=self.vm,
+            dc_bound=True,
             serializer=ser,
             data=self.data,
             graph=graph,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,7 @@ Features
 Bugs
 ----
 
+- Fixed bug that caused node monitoring graphs not to show, when not in main DC -  `#100 <https://github.com/erigones/esdc-ce/issues/100>`__
 
 
 2.5.0 (released on 2017-03-03)


### PR DESCRIPTION
This only happened when user was not in main DC.
Issue #100