### PR TITLE
added explicit roles_path to ansible.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ celerybeat-schedule*
 
 # Ansible
 ans/hosts.cfg
+ans/ha/cfg/local_vars.yml

--- a/ans/ansible.cfg
+++ b/ans/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 inventory = hosts.cfg
 library = library/
+roles_path = roles/
 remote_user = root
 module_name = shell
 gathering = explicit


### PR DESCRIPTION
This change allows reusability of roles by diferrent ansible scripts.