### PR TITLE
Images are ordered by default by date, reversed now. Closes #113

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,8 @@ Bugs
 - Fixed 500 error during xls bulk import when ostype does not exist - `#121 <https://github.com/erigones/esdc-ce/issues/121>`__
 - Fixed race conditions when using `set_request_method()` and `call_api_view()` functions - `#123 <https://github.com/erigones/esdc-ce/issues/123>`__
 - Fixed `get_owners` convenience function that sometimes returned duplicate users, which resulted in occasional errors - `#136 <https://github.com/erigones/esdc-ce/issues/136>`__
+- Fixed default image import list, where last 30 results were not selected by the published date - `#113 <https://github.com/erigones/esdc-ce/issues/113>`__
+
 
 2.5.1 (released on 2017-03-07)
 ==============================

--- a/vms/models/imagestore.py
+++ b/vms/models/imagestore.py
@@ -1,4 +1,5 @@
 from hashlib import md5
+from operator import itemgetter
 from frozendict import frozendict
 from django.utils.translation import ugettext_lazy as _
 from django.utils.text import Truncator
@@ -136,10 +137,14 @@ class ImageStore(_DummyModel):
 
         return images
 
-    def save_images(self, images):
+    @staticmethod
+    def _ordering_newest_first(images):
+        return sorted(images, key=itemgetter('created'), reverse=True)
+
+    def save_images(self, images, order=_ordering_newest_first):
         cache.set(
             self._cache_key_images,
-            [ImageStoreObject(img, self.get_image_manifest_url(img['uuid'])) for img in images]
+            order(ImageStoreObject(img, self.get_image_manifest_url(img['uuid'])) for img in images)
         )
 
     def delete_images(self):


### PR DESCRIPTION
Frontend is relying on this behavior, because the default view, "Show last 30 published images" expects the last 30 images to be the first to arrive from the backend.