### PR TITLE
get_owners function returns distincted queryset now. Closes #136

### DIFF
--- a/api/vm/utils.py
+++ b/api/vm/utils.py
@@ -172,7 +172,7 @@ def get_owners(request, dc=None, all=False, order_by=('username',)):
     Return QuerySet of all active users. WARNING: Use with care!
     """
     dc = dc or request.dc
-    qs = User.objects.exclude(id=settings.SYSTEM_USER).filter(is_active=True).order_by(*order_by)
+    qs = User.objects.exclude(id=settings.SYSTEM_USER).filter(is_active=True).order_by(*order_by).distinct()
 
     if all or dc.access == dc.PUBLIC:
         # Public DC is available for all active users

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,7 +19,7 @@ Bugs
 - Added template for HTTP 403 status code - `#96 <https://github.com/erigones/esdc-ce/issues/96>`__
 - Fixed 500 error during xls bulk import when ostype does not exist - `#121 <https://github.com/erigones/esdc-ce/issues/121>`__
 - Fixed race conditions when using `set_request_method()` and `call_api_view()` functions - `#123 <https://github.com/erigones/esdc-ce/issues/123>`__
-
+- Fixed `get_owners` convenience function that sometimes returned duplicate users, which resulted in occasional errors - `#136 <https://github.com/erigones/esdc-ce/issues/136>`__
 
 2.5.1 (released on 2017-03-07)
 ==============================


### PR DESCRIPTION
Outer join on line 186 causes occurrence of duplicate objects in the queryset, which sometimes resulted in an error.