### PR TITLE
Fixed 500 error when DNS domain owner is NULL in DB - closes #116

### DIFF
--- a/api/dns/domain/serializers.py
+++ b/api/dns/domain/serializers.py
@@ -18,7 +18,7 @@ class DomainSerializer(s.InstanceSerializer):
     name_changed = None
 
     name = s.RegexField(r'^[A-Za-z0-9][A-Za-z0-9\._/-]*$', max_length=253, min_length=3)
-    owner = s.SlugRelatedField(slug_field='username', queryset=User.objects, required=False)
+    owner = s.SlugRelatedField(slug_field='username', queryset=User.objects)
     access = s.IntegerChoiceField(choices=Domain.ACCESS, default=Domain.PRIVATE)
     desc = s.SafeCharField(max_length=128, required=False)
     created = s.DateTimeField(read_only=True, required=False)

--- a/api/dns/domain/utils.py
+++ b/api/dns/domain/utils.py
@@ -69,7 +69,7 @@ def prefetch_domain_owner(domain_qs):
     users = {user.id: user for user in Domain.get_user_model().objects.filter(id__in=user_ids)}
 
     for domain in domain_qs:
-        domain._owner = users.get(domain.user, None)
+        domain._owner = users.get(domain.user, Domain.NoOwner())
 
     return domain_qs
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ Bugs
 
 - Added template for HTTP 403 status code - `#96 <https://github.com/erigones/esdc-ce/issues/96>`__
 - Fixed errors in graph descriptions - `#112 <https://github.com/erigones/esdc-ce/issues/112>`__
+- Fixed 500 error when DNS domain owner is NULL in DB - `#116 <https://github.com/erigones/esdc-ce/issues/116>`__
 - Fixed list of images to be deleted in *Delete unused images* modal - `#117 <https://github.com/erigones/esdc-ce/issues/117>`__
 - Fixed 500 error during xls bulk import when ostype does not exist - `#121 <https://github.com/erigones/esdc-ce/issues/121>`__
 - Fixed race conditions when using `set_request_method()` and `call_api_view()` functions - `#123 <https://github.com/erigones/esdc-ce/issues/123>`__

--- a/pdns/models/domain.py
+++ b/pdns/models/domain.py
@@ -4,6 +4,17 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import get_user_model
 
 
+class EmptyDomainOwner(object):
+    """
+    Dummy model used as the owner attribute in case the domain.id is NULL.
+    """
+    def __getattr__(self, item):
+        return None
+
+    def __str__(self):
+        return ''
+
+
 class Domain(models.Model):
     """
     This table contains all the domain names that your pdns-server is handling
@@ -30,6 +41,7 @@ class Domain(models.Model):
     + created field (null=True)
     + changed field (null=True)
     """
+    NoOwner = EmptyDomainOwner
     QServerExclude = Q(name__iendswith='in-addr.arpa')
     _user_model = None  # Cache the User model
     _owner = models.Empty  # Owner (user) object cache
@@ -136,9 +148,9 @@ class Domain(models.Model):
                 try:
                     self._owner = user_model.objects.get(pk=self.user)
                 except user_model.DoesNotExist:
-                    self._owner = None
+                    self._owner = self.NoOwner()
             else:
-                self._owner = None
+                self._owner = self.NoOwner()
         return self._owner
 
     @owner.setter

--- a/pdns/models/domain.py
+++ b/pdns/models/domain.py
@@ -14,6 +14,10 @@ class EmptyDomainOwner(object):
     def __str__(self):
         return ''
 
+    def __nonzero__(self):
+        return False
+    __bool__ = __nonzero__
+
 
 class Domain(models.Model):
     """


### PR DESCRIPTION
- Added Domain.NoOwner class as a dummy model for situations where the domain.user field is NULL. This object returns None when accessing any attribute.
- Fixed DomainSerializer.owner - this attribute must be required.