### PR TITLE
Fixed allowed_ips errors when undo change on vm nic

### DIFF
--- a/api/vm/define/serializers.py
+++ b/api/vm/define/serializers.py
@@ -1115,7 +1115,7 @@ class VmDefineNicSerializer(s.Serializer):
             ret['ip'] = self.object.get('ip', None)
             ret['netmask'] = self.object.get('netmask', None)
             ret['gateway'] = self.object.get('gateway', None)
-            ret['allowed_ips'] = self.object.get('allowed_ips', set())
+            ret['allowed_ips'] = self.object.get('allowed_ips', [])
 
         return ret
 
@@ -1278,10 +1278,9 @@ class VmDefineNicSerializer(s.Serializer):
                 self._ip_old = self._ip
                 self._ip = None
 
-        allowed_ips = attrs.get('allowed_ips', set())
+        allowed_ips = set(attrs.get('allowed_ips', ()))
 
         if allowed_ips:
-            allowed_ips = set(allowed_ips)
             _ips = IPAddress.objects.filter(ip__in=allowed_ips, subnet=net)
 
             if self.object and not self._net_old and self._ips and self._ips == _ips:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Bugs
 ----
 
 - Added template for HTTP 403 status code - `#96 <https://github.com/erigones/esdc-ce/issues/96>`__
+- Fixed 500 AttributeError: 'unicode' object has no attribute 'iteritems' when doing VM undo - `#115 <https://github.com/erigones/esdc-ce/issues/115>`__
 - Fixed 500 error during xls bulk import when ostype does not exist - `#121 <https://github.com/erigones/esdc-ce/issues/121>`__
 
 


### PR DESCRIPTION
We were receiving 500 error when allowed_ips is defined and user hits
undo button (issue #115). Once _diff_lists were aplied we received allowed_ips in add
section instead of change. I have changed serialiezr to have set instead
of list, which resulted in correct diff and also sanitaze if user adds
twice the same IP.