### PR TITLE
Moved Create DNS checkbox to non advanced section when creating (edit ing) NIC in VM issue

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Features
 - Added visual flash for objects (table rows) added, updated or removed to/from a table - - `#125 <https://github.com/erigones/esdc-ce/issues/125>`__
 - Allow to update disk size of a running VM - requiring only one reboot to take effect - `#127 <https://github.com/erigones/esdc-ce/issues/127>`__
 - Added current_dc (read_only) attribute to output of user_list, user_manage and dc_user(_list) views - `#131 <https://github.com/erigones/esdc-ce/issues/131>`__
+- Moved Create DNS checkbox to non advanced section when creating (editing) NIC in VM - `#145 <https://github.com/erigones/esdc-ce/issues/145>`__
 
 Bugs
 ----

--- a/gui/templates/gui/vm/nic_settings_form.html
+++ b/gui/templates/gui/vm/nic_settings_form.html
@@ -10,6 +10,7 @@
 {% if vm.is_kvm %}{% include "gui/form_field.html" with field=nic_settingsform.model %}{% endif %}
 {% include "gui/form_field.html" with field=nic_settingsform.net %}
 {% include "gui/form_field.html" with field=nic_settingsform.ip %}
+{% include "gui/form_field_checkbox.html" with field=nic_settingsform.dns class="thin" %}
 <div class="advanced hide">
 {% include "gui/form_field.html" with field=nic_settingsform.mac %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.primary %}
@@ -20,7 +21,6 @@
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.allow_ip_spoofing %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.allow_mac_spoofing %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.allow_restricted_traffic %}
-{% include "gui/form_field_checkbox.html" with field=nic_settingsform.dns class="thin" %}
 </div>
 {% else %}
 {% if vm.is_kvm %}{% include "gui/form_field.html" with field=nic_settingsform.model class="thin" %}{% endif %}


### PR DESCRIPTION
Reason for doing this is that we do create DNS record automatically for the first NIC that is added to VM. Which is a bit magic for user if he doesn't see this check box. If he removes the NIC and than try to re-create no DNS record is created.