### PR TITLE
Fixed VM hostname fetching in `message_callback` (GUI/JS)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Features
 Bugs
 ----
 
+- Fixed VM hostname fetching in `message_callback` (GUI/JS) - `#159 <https://github.com/erigones/esdc-ce/issues/159>`__
 
 
 2.5.2 (released on 2017-04-11)

--- a/gui/static/gui/js/gsio.js
+++ b/gui/static/gui/js/gsio.js
@@ -381,7 +381,7 @@ function update_sio_status() {
 
 // callback: "message"
 function message_callback(code, res, view, method, args, kwargs, apiview, apidata) {
-  var hostname = kwargs.hostname || args[0] || null;
+  var hostname = apiview.hostname || kwargs.hostname || kwargs.hostname_or_uuid || args[0] || null;
   var target_hostname = hostname;  // get target_hostname (real VM)
   var data = kwargs;
   var task_id = res.task_id || null;
@@ -394,8 +394,13 @@ function message_callback(code, res, view, method, args, kwargs, apiview, apidat
   if ('data' in kwargs) {
     data = kwargs.data;
   }
-  if ('target_hostname' in data) {
+
+  if ('target_hostname' in apiview) {
+    target_hostname = apiview.target_hostname;
+  } else if ('target_hostname' in data) {
     target_hostname = data.target_hostname;
+  } else if ('target_hostname_or_uuid' in data) {
+    target_hostname = data.target_hostname_or_uuid;
   }
 
   // always update task list if it exists


### PR DESCRIPTION
After introduction of hostname_or_uuid for VMs (#16) the `message_callback` had received the hostname attribute in a `hostname_or_uuid` field. In case of a started task the hostname field is stored in the apiview - so the apiview.hostname should be used as a primary source of VM hostname. 