### PR TITLE
Hidden input fields for disabled modules due to issue #146

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Features
 - Add support for appending additional SSH authorized_keys into the service VMs - `esdc-factory#43 <https://github.com/erigones/esdc-factory/issues/43>`__
 - Added GET mon_template_list and GET mon_hostgroup_list API views for listing monitoring templates and hostgroups - `#90 <https://github.com/erigones/esdc-ce/issues/90>`__
 - Added dropdown menus (with tags support) to form fields for selecting monitoring templates and hostgroups - `#90 <https://github.com/erigones/esdc-ce/issues/90>`__
+- Hidden input fields for disabled modules - `#146 <https://github.com/erigones/esdc-ce/issues/146>`__
 - Create required `domainmetadata` for every newly created domain - `#151 <https://github.com/erigones/esdc-ce/issues/151>`__
 - Updated API call `PUT vm_manage` to support forced change of the node on the VM - `#154 <https://github.com/erigones/esdc-ce/issues/154>`__
 - Updated backup functionality to store metadata on backup node - `#155 <https://github.com/erigones/esdc-ce/issues/155>`__

--- a/gui/templates/gui/node/define_form.html
+++ b/gui/templates/gui/node/define_form.html
@@ -8,11 +8,15 @@
 {% include "gui/form_field.html" with field=form.owner %}
 {% include "gui/form_field.html" with field=form.status %}
 {% include "gui/form_field_checkbox.html" with field=form.is_compute %}
+{% if settings.VMS_VM_BACKUP_ENABLED %}
 {% include "gui/form_field_checkbox.html" with field=form.is_backup %}
+{% endif %}
 
 <div class="advanced hide">
 {% include "gui/form_field.html" with field=form.cpu_coef %}
 {% include "gui/form_field.html" with field=form.ram_coef %}
+{% if settings.MON_ZABBIX_ENABLED %}
 {% include "gui/form_field.html" with field=form.monitoring_templates %}
 {% include "gui/form_field.html" with field=form.monitoring_hostgroups %}
+{% endif %}
 </div>

--- a/gui/templates/gui/vm/nic_settings_form.html
+++ b/gui/templates/gui/vm/nic_settings_form.html
@@ -10,11 +10,15 @@
 {% if vm.is_kvm %}{% include "gui/form_field.html" with field=nic_settingsform.model %}{% endif %}
 {% include "gui/form_field.html" with field=nic_settingsform.net %}
 {% include "gui/form_field.html" with field=nic_settingsform.ip %}
+{% if dc_settings.DNS_ENABLED %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.dns class="thin" %}
+{% endif %}
 <div class="advanced hide">
 {% include "gui/form_field.html" with field=nic_settingsform.mac %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.primary %}
+{% if dc_settings.MON_ZABBIX_ENABLED %}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.monitoring %}
+{% endif %}
 {# {% include "gui/form_field.html" with field=nic_settingsform.allowed_ips %} #}
 {# {% include "gui/form_field.html" with field=nic_settingsform.blocked_outgoing_ports %} #}
 {% include "gui/form_field_checkbox.html" with field=nic_settingsform.allow_dhcp_spoofing %}

--- a/gui/templates/gui/vm/settings_form.html
+++ b/gui/templates/gui/vm/settings_form.html
@@ -32,7 +32,9 @@
 {% include "gui/form_field.html" with field=settingsform.ram addon=mb_addon %}
 
 <div class="advanced hide">
+{% if dc_settings.MON_ZABBIX_ENABLED %}
 {% include "gui/form_field_checkbox.html" with field=settingsform.monitored %}
+{% endif %}
 {% include "gui/form_field_checkbox.html" with field=settingsform.installed %}
 {% include "gui/form_field.html" with field=settingsform.snapshot_limit_manual %}
 {% include "gui/form_field.html" with field=settingsform.snapshot_size_limit addon=mb_addon %}
@@ -40,8 +42,10 @@
 {% include "gui/form_field.html" with field=settingsform.zfs_io_priority %}
 {% include "gui/form_field.html" with field=settingsform.zpool %}
 {% include "gui/form_field.html" with field=settingsform.owner %}
+{% if dc_settings.MON_ZABBIX_ENABLED %}
 {% include "gui/form_field.html" with field=settingsform.monitoring_templates %}
 {% include "gui/form_field.html" with field=settingsform.monitoring_hostgroups class="thin" %}
+{% endif %}
 {% include "gui/form_field.html" with field=settingsform.mdata %}
 </div>
 

--- a/gui/templates/gui/vm/settings_form.html
+++ b/gui/templates/gui/vm/settings_form.html
@@ -36,8 +36,10 @@
 {% include "gui/form_field_checkbox.html" with field=settingsform.monitored %}
 {% endif %}
 {% include "gui/form_field_checkbox.html" with field=settingsform.installed %}
+{% if dc_settings.VMS_VM_SNAPSHOT_ENABLED %}
 {% include "gui/form_field.html" with field=settingsform.snapshot_limit_manual %}
 {% include "gui/form_field.html" with field=settingsform.snapshot_size_limit addon=mb_addon %}
+{% endif %}
 {% include "gui/form_field.html" with field=settingsform.cpu_shares %}
 {% include "gui/form_field.html" with field=settingsform.zfs_io_priority %}
 {% include "gui/form_field.html" with field=settingsform.zpool %}


### PR DESCRIPTION
Once module is disabled in DC settings we shouldn't display input fields for this module. They weren't doing anything so it was just confusing for user.