### PR TITLE
Fixed plotting of longterm graphs

### DIFF
--- a/api/mon/backends/zabbix/base.py
+++ b/api/mon/backends/zabbix/base.py
@@ -1,7 +1,7 @@
-from logging import getLogger
+from logging import getLogger, INFO, WARNING, CRITICAL, ERROR
 from time import time
+from operator import itemgetter
 from datetime import datetime
-from logging import INFO, WARNING, CRITICAL, ERROR
 from subprocess import call
 
 from django.utils.six import iteritems
@@ -804,7 +804,8 @@ class ZabbixBase(object):
             if since_trend and until_trend:
                 params['time_from'] = since_trend
                 params['time_till'] = until_trend
-                res['history'] = self.zapi.trend.get(params)
+                # Zabbix trend.get does not support sorting -> https://support.zabbix.com/browse/ZBXNEXT-3974
+                res['history'] = sorted(self.zapi.trend.get(params), key=itemgetter('clock'))
 
             if since_history and until_history:
                 params['time_from'] = since_history

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 #########
 
-2.6.0 (unreleased)
+2.6.1 (unreleased)
 ==================
 
 Features

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 #########
 
+2.6.0 (unreleased)
+==================
+
+Features
+--------
+
+Bugs
+----
+
+- Fixed plotting of longterm graphs - `#209 <https://github.com/erigones/esdc-ce/issues/209>`__
+
+
 2.6.0 (released on 2017-07-21)
 ==============================
 


### PR DESCRIPTION
The current implementation produced unsorted data from the Zabbix API,
which was not expected by the JS plotting library and produced strange
graphs in browser. The best solution is to implement sorting in the
`trends.get` API call - https://support.zabbix.com/browse/ZBXNEXT-3974.
In the meantime we will sort the data on the mgmt server.