### PR TITLE
Disable locale switching when editing other user's settings

### DIFF
--- a/api/accounts/user/profile/serializers.py
+++ b/api/accounts/user/profile/serializers.py
@@ -98,7 +98,10 @@ class UserProfileSerializer(InstanceSerializer):
             send_sms(profile.phone, msg)
 
         profile.save()
-        profile.activate_locale(self.request)
+
+        # We cannot change active language settings for other user than ourself
+        if self.request.user == profile.user:
+            profile.activate_locale(self.request)
 
     def validate_phone(self, attrs, source):
         try:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Features
 Bugs
 ----
 
+- Disabled locale switching when editing other user's settings - `#224 <https://github.com/erigones/esdc-ce/issues/224>`__
 - Disabled form submit when pressing Enter in Add Ticket form - `#220 <https://github.com/erigones/esdc-ce/issues/220>`__
 - Fixed critical problem with Detach button calling the Delete action - `#219 <https://github.com/erigones/esdc-ce/issues/219>`__
 - Fixed single element representation in array fields - `#216 <https://github.com/erigones/esdc-ce/issues/216>`__


### PR DESCRIPTION
We cannot change active language settings for other users, because we cannot change other user's session.