### PR TITLE
Renamed `GET /task/log/report` to `GET /task/log/stats`

### DIFF
--- a/api/task/serializers.py
+++ b/api/task/serializers.py
@@ -4,7 +4,7 @@ from operator import and_
 
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from django.db.models import Q, Count
+from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
 from celery import states
 from pytz import UTC
@@ -124,25 +124,3 @@ class TaskLogFilterSerializer(s.Serializer):
             return reduce(and_, query)
         else:
             return None
-
-
-class TaskLogReportSerializer(s.Serializer):
-    """
-    Display task log stats.
-    """
-    pending = s.IntegerField(read_only=True)
-    revoked = s.IntegerField(read_only=True)
-    succeeded = s.IntegerField(read_only=True)
-    failed = s.IntegerField(read_only=True)
-
-    @classmethod
-    def get_report(cls, basequery):
-        def get_count(status):
-            return basequery.filter(status=status).aggregate(count=Count('id')).get('count', 0)
-
-        return {
-            'pending': get_count(states.PENDING),
-            'revoked': get_count(states.REVOKED),
-            'succeeded': get_count(states.SUCCESS),
-            'failed': get_count(states.FAILURE),
-        }

--- a/api/task/task_log.py
+++ b/api/task/task_log.py
@@ -53,18 +53,15 @@ class TaskLogView(APIView):
         }
 
     def get_stats(self):
+        """api.task.views.task_log_stats"""
         try:
             last = int(self.data.get('last', 86400))
             startime = timezone.now() - timedelta(seconds=last)
-        except:
+        except Exception:  # This also catches the OverflowError raised during startime calculation
             raise InvalidInput('Invalid "last" parameter')
 
         qs = get_tasklog(self.request, sr=(), time__gte=startime)
         res = self._get_stats_result(qs)
         res['_last'] = last
 
-        return res
-
-    def get_stats_response(self):
-        """api.task.views.task_log_stats"""
-        return TaskSuccessResponse(self.request, self.get_stats())
+        return TaskSuccessResponse(self.request, res)

--- a/api/task/task_views.py
+++ b/api/task/task_views.py
@@ -5,14 +5,14 @@ from que.utils import user_owner_dc_ids_from_task_id
 from que.user_tasks import UserTasks
 from api.decorators import api_view, request_data
 from api.serializers import ForceSerializer
-from api.permissions import IsSuperAdminOrReadOnly
+from api.permissions import IsSuperAdminOrReadOnly, IsAdmin
 from api.task.response import TaskStatusResponse, TaskDoneResponse, TaskSuccessResponse, TaskFailureResponse
 from api.task.permissions import IsUserTask, IsTaskCreator
 from api.task.utils import get_user_tasks, cancel_task, delete_task
 from api.task.serializers import TaskCancelSerializer
 from api.task.task_log import TaskLogView
 
-__all__ = ('task_list', 'task_details', 'task_status', 'task_done', 'task_cancel', 'task_log', 'task_log_report')
+__all__ = ('task_list', 'task_details', 'task_status', 'task_done', 'task_cancel', 'task_log', 'task_log_stats')
 
 
 # noinspection PyUnusedLocal
@@ -231,20 +231,23 @@ dc, vm, node, nodestorage, subnet, image, vmtemplate, iso, domain, user, role)
 
 
 @api_view(('GET',))
-@request_data()
-def task_log_report(request, data=None):
+@request_data(permissions=(IsAdmin,))
+def task_log_stats(request, data=None):
     """
-    Display (:http:get:`GET </task/log/report>`) task log statistics.
+    Display (:http:get:`GET </task/log/stats>`) task log statistics.
 
-    .. http:get:: /task/log/report
+    .. http:get:: /task/log/stats
 
         :DC-bound?:
             * |dc-yes|
         :Permissions:
+            * |Admin|
+        :Asynchronous?:
+            * |async-no|
         :arg data.last: Use task log entries which are n seconds old (default: 86400)
         :type data.last: integer
         :status 200: Object with *succeeded*, *failed*, *pending* and *revoked* attributes
         :status 400: Error object with "detail" attribute
         :status 403: Forbidden
     """
-    return TaskLogView(request, data=data).report()
+    return TaskLogView(request, data=data).get_stats_response()

--- a/api/task/task_views.py
+++ b/api/task/task_views.py
@@ -250,4 +250,4 @@ def task_log_stats(request, data=None):
         :status 400: Error object with "detail" attribute
         :status 403: Forbidden
     """
-    return TaskLogView(request, data=data).get_stats_response()
+    return TaskLogView(request, data=data).get_stats()

--- a/api/task/urls.py
+++ b/api/task/urls.py
@@ -4,7 +4,7 @@ urlpatterns = patterns(
     'api.task.views',
 
     url(r'^log/$', 'task_log', name='api_task_log'),
-    url(r'^log/report/$', 'task_log_report', name='api_task_log_report'),
+    url(r'^log/stats/$', 'task_log_stats', name='api_task_log_stats'),
     url(r'^(?P<task_id>[A-Za-z0-9-]+)/done/$', 'task_done', name='api_task_done'),
     url(r'^(?P<task_id>[A-Za-z0-9-]+)/status/$', 'task_status', name='api_task_status'),
     url(r'^(?P<task_id>[A-Za-z0-9-]+)/state/$', 'task_status', name='api_task_state'),

--- a/doc/api/es_bash_completion.sh
+++ b/doc/api/es_bash_completion.sh
@@ -141,6 +141,10 @@ _es() {
 			[[ "${action}" == "set" ]] && params="-name -alias -users -permissions -dc_bound -dcs"
 		;;
 
+		/task/log/stats)
+			[[ "${action}" == "get" ]] && params="-last"
+		;;
+
 		/task/log|/task/log/)
 			[ ${COMP_CWORD} -eq 2 ] && COMPREPLY=( "${cur} " )
 			params="-page -status -object_type -object_name -show_running -hide_auto -date_from -date_to"

--- a/doc/api/source/api/task.rst
+++ b/doc/api/source/api/task.rst
@@ -162,3 +162,30 @@
                 ]
             }
         }
+
+
+/task/log/stats
+---------------
+
+.. autofunction:: api.task.views.task_log_stats
+
+    |es example|:
+
+    .. sourcecode:: bash
+
+        es get /task/log/stats
+
+    .. sourcecode:: json
+
+        {
+            "url": "https://my.erigones.com/api/task/log/stats/",
+            "status": 200,
+            "method": "GET",
+            "text": {
+                "failed": 0,
+                "pending": 7722,
+                "succeeded": 7738,
+                "revoked": 0,
+                "_last": 86400
+            }
+        }

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,8 @@ Changelog
 Features
 --------
 
+- Renamed ``GET /task/log/report`` to ``GET /task/log/stats`` to be consistent with future *stats* views - `#232 <https://github.com/erigones/esdc-ce/issues/232>`__
+
 Bugs
 ----
 


### PR DESCRIPTION
Refactored task_log_report to task_log_stats to be consistent with future stats API views. Plus, this commit fixes documentation issues and removes obsolete code.