### PR TITLE
Updated registration help texts in issue #225

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Features
 --------
 
 - Renamed ``GET /task/log/report`` to ``GET /task/log/stats`` to be consistent with future *stats* views - `#232 <https://github.com/erigones/esdc-ce/issues/232>`__
+- Simplify registration and password reset - `#225 <https://github.com/erigones/esdc-ce/issues/225>`__
 
 Bugs
 ----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,7 +9,7 @@ Features
 --------
 
 - Renamed ``GET /task/log/report`` to ``GET /task/log/stats`` to be consistent with future *stats* views - `#232 <https://github.com/erigones/esdc-ce/issues/232>`__
-- Simplify registration and password reset - `#225 <https://github.com/erigones/esdc-ce/issues/225>`__
+- Simplified registration and password reset - `#225 <https://github.com/erigones/esdc-ce/issues/225>`__
 
 Bugs
 ----

--- a/gui/accounts/forms.py
+++ b/gui/accounts/forms.py
@@ -79,14 +79,13 @@ class ForgotForm(_PasswordResetForm):
             'placeholder': _('Your email address'),
             'required': 'required'
         }
-        self.fields['email'].help_text = _('You will receive a validation email with instruction on how to reset your '
-                                           'password.')
+        self.fields['email'].help_text = _('You will receive an email with instructions on how to reset your password.')
 
     # noinspection PyArgumentList,PyUnusedLocal
     def clean_email(self, *args, **kwargs):
         """
-        We never raise an ValidationError, because of bug #chili-295 -
-        user Enumeration and Guessable User Account OWASP-AT-002.
+        We never raise an ValidationError, because user Enumeration and Guessable User Account OWASP-AT-002.
+        Change this behaviour with settings.SECURITY_OWASP_AT_002.
         """
         email = self.cleaned_data['email']
         users = User.objects.filter(email__iexact=email, is_active=True).exclude(password=UNUSABLE_PASSWORD)
@@ -167,7 +166,7 @@ class RegisterForm(forms.ModelForm):
     User details registration form, for basic user data (Django users table)
     """
     validate_against_users = True
-    email_help_text = _('You will receive a validation email to activate your account.')
+    email_help_text = _('You will receive an email to activate your account.')
 
     class Meta:
         model = User
@@ -218,8 +217,7 @@ class UserProfileRegisterForm(forms.ModelForm):
     include_company = False
     include_tos = bool(settings.TOS_LINK)
     include_others = True
-    phone_help_text = _('You will receive a text message with an auto-generated password which you can change after '
-                        'login.')
+    phone_help_text = _('You will receive a text message (SMS) with password.')
 
     class Meta:
         model = UserProfile

--- a/gui/accounts/views.py
+++ b/gui/accounts/views.py
@@ -56,8 +56,9 @@ def registration_done(request):
         'header': _('Registration almost complete!'),
         'blocks': (
             (_('Thank you for registering at %s.') % request.dc.settings.SITE_NAME),
-            _('A verification email has been send to your email address. Please click on the link in the email to '
-              'activate your account.'),
+            _('You should receive an email shortly. Please click on the link in the email to activate your account.'),
+            _('If you don\'t receive an email, please check your spam folder.'),
+            _('Once your account is active, you will receive a text message (SMS) with your password.')
         )
     }
     return render(request, 'gui/note.html', context)
@@ -196,7 +197,7 @@ def forgot_passwd_check_done(request):
     context = {
         'header': _('Password reset!'),
         'blocks': (
-            _('Your password has been reset and send to your phone number via text message.'),
+            _('Your password has been reset and send to your phone number via text message (SMS).'),
         ),
         'links': (
             {'label': 'You may go ahead and log in now.', 'url': reverse('login')},

--- a/gui/templates/gui/accounts/forgot_check.html
+++ b/gui/templates/gui/accounts/forgot_check.html
@@ -1,12 +1,14 @@
 {% extends "base_no_auth.html" %}
 {% load i18n %}
 
+{% block body_class %} onload="document.getElementById('submitForm').submit();"{% endblock %}
+
 {% block login_content %}{% if validlink %}
-<form class="form-horizontal"  action="" method="POST">
+<form class="form-horizontal" id="submitForm" action="" method="POST">
   {% csrf_token %}
   <div class="no-auth-message black-box inner-well">
     <h4>{% trans "Password reset" %}</h4>
-    <p>{% trans "Your new password will be send as text message to your phone number." %}</p>
+    <p>{% trans "Your new password will be send as a text message (SMS) to your phone number." %}</p>
   </div>
   <button type="submit" class="no-auth-button">{% trans "Reset my password" %}</button>
 </form>

--- a/gui/templates/gui/accounts/forgot_check.html
+++ b/gui/templates/gui/accounts/forgot_check.html
@@ -1,7 +1,13 @@
 {% extends "base_no_auth.html" %}
 {% load i18n %}
 
-{% block body_class %} onload="document.getElementById('submitForm').submit();"{% endblock %}
+{% block head %}
+<script type="text/javascript">
+$(document).ready(function(){
+   $("form#submitForm").submit();
+});
+</script>
+{% endblock %}
 
 {% block login_content %}{% if validlink %}
 <form class="form-horizontal" id="submitForm" action="" method="POST">

--- a/gui/templates/gui/accounts/forgot_check.html
+++ b/gui/templates/gui/accounts/forgot_check.html
@@ -4,13 +4,13 @@
 {% block head %}
 <script type="text/javascript">
 $(document).ready(function(){
-   $("form#submitForm").submit();
+   $('#password-reset').submit();
 });
 </script>
 {% endblock %}
 
 {% block login_content %}{% if validlink %}
-<form class="form-horizontal" id="submitForm" action="" method="POST">
+<form class="form-horizontal" id="password-reset" action="" method="POST">
   {% csrf_token %}
   <div class="no-auth-message black-box inner-well">
     <h4>{% trans "Password reset" %}</h4>

--- a/gui/templates/gui/accounts/forgot_email.txt
+++ b/gui/templates/gui/accounts/forgot_email.txt
@@ -4,7 +4,7 @@
 
 {{ site_link }}{% url 'forgot_check' uidb64=uid token=token %}
 
-{% trans "Your new password will be send as text message to your phone number:" %} {{ user.userprofile.phone }}
+{% trans "Your new password will be send as text message (SMS) to your phone number:" %} {{ user.userprofile.phone }}
 {% trans "Your username (email address), in case you've forgotten:" %} {{ user.username }}
 {% endautoescape %}
 

--- a/gui/templates/gui/accounts/forgot_subject.txt
+++ b/gui/templates/gui/accounts/forgot_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}Password reset on {{ site_name }}{% endblocktrans %}
+{% blocktrans %}Password reset request on {{ site_name }}{% endblocktrans %}
 {% endautoescape %}

--- a/gui/templates/gui/accounts/register_check.html
+++ b/gui/templates/gui/accounts/register_check.html
@@ -8,12 +8,13 @@
   <h4>{% trans "Registration complete!" %}</h4>
   <br>
   <p>{% blocktrans %}Welcome to {{ site_name }}!{% endblocktrans %}</p>
-  <p>{% blocktrans with phone=profile.phone %}Your password has been sent to your phone number {{ phone }} as text message.{% endblocktrans %} <a href="{% url 'login' %}" class="btn-link">{% trans "You may go ahead and log in now." %}</a></p>
+  <p>{% blocktrans with phone=profile.phone %}Your password has been sent to your phone number {{ phone }} as text message (SMS).{% endblocktrans %}</p>
+  <p><a href="{% url 'login' %}" class="btn-link">{% trans "You may go ahead and log in now." %}</a></p>
   {% else %}
   <h4>{% trans "Registration problem :(" %}</h4>
   <br>
   <p>{% blocktrans %}Welcome to {{ site_name }}!{% endblocktrans %}</p>
-  <p>{% blocktrans with phone=profile.phone %}There was an error while sending a text message with your new password to your phone number {{ phone }}. Please contact us at <b>{{ support_email }}</b>.{% endblocktrans %}
+  <p>{% blocktrans with phone=profile.phone %}There was an error while sending a text message (SMS) with your new password to your phone number {{ phone }}. Please contact us at <b>{{ support_email }}</b>.{% endblocktrans %}
   {% endif %}
   {% else  %}
   <h4>{% trans "Registration problem :(" %}</h4>

--- a/gui/templates/gui/accounts/register_email.txt
+++ b/gui/templates/gui/accounts/register_email.txt
@@ -2,13 +2,17 @@
 
 Welcome to {{ site_name }}!
 
-In order to finish registration and activate your account please follow this link:{% endblocktrans %}
+In order to finish registration, activate your account by following this link:{% endblocktrans %}
 
 {{ site_link }}{% url 'registration_check' uidb64=uid token=token %}
 
+{% trans "Once your account is active, you will receive a text message (SMS) with your password." %}
+
 {% trans "Your login details are:" %}
+
 {% trans "Username (email address):" %} {{ user.username }}
-{% trans "Password will be send to phone number:" %} {{ profile.phone }}
+{% trans "Password (will be sent):" %} **********
+{% trans "Phone number (for SMS):" %} {{ profile.phone }}
 
 {% blocktrans %}Thank you for choosing {{ site_name }}.{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
I have simplified texts on the form (two lines of small words) was
barely readable, and added SMS in the text so user can notice.

Updated email texts to have explaining sentence and also moved the
data into "blocks" so it is more visualy more obvious to notice
stars insttead of password so user will notice that password will
be send out by text message (SMS).

Reset password form is automatically submitted by javascript in
order to send password via SMS. We do re-use the Django reset from
that is the reason we have to have the form there and submit.