### PR TITLE
made allowed ips type list everywhere

### DIFF
--- a/api/node/vm/utils.py
+++ b/api/node/vm/utils.py
@@ -165,7 +165,7 @@ def vm_from_json(request, task_id, json, dc, owner=settings.ADMIN_USER, template
                 if i == 0:
                     primary_ip = ip
 
-                for ipaddress in nic.get('allowed_ips', ()):
+                for ipaddress in nic.get('allowed_ips', []):
                     _, err = _vm_save_ip_from_json(vm, net, ipaddress, allowed_ips=True)
 
                     if err:

--- a/api/vm/base/utils.py
+++ b/api/vm/base/utils.py
@@ -92,7 +92,7 @@ def vm_update_ipaddress_usage(vm):
 
         if network_uuid:
             ip = nic.get('ip', '')
-            allowed_ips = nic.get('allowed_ips', ())
+            allowed_ips = nic.get('allowed_ips', [])
 
             if ip:
                 logger.debug('VM: %s | NIC ID: %s | NIC network: %s | IP address: %s', vm, nic_id, network_uuid, ip)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Features
 Bugs
 ----
 
+- Fixed allowed_ips type on all occurrences to list instead of set to enable JSON serialization - `#242 <https://github.com/erigones/esdc-ce/issues/242>`__
 - Fixed behaviour after user permission change that leads to change of user's current DC - `#108 <https://github.com/erigones/esdc-ce/issues/108>`__
 - Fixed SMSAPI return response status code 200 but text of the response is ERROR - `#230 <https://github.com/erigones/esdc-ce/issues/230>`__
 


### PR DESCRIPTION
It was not possible to serialize (and therefore deploy) VM after using allowed_ips parameter in the VM definition, as the type of allowed_ips was set to set. Set is not JSON serializable. 
Default values were changed to promote the expected value in the variable.