### PR TITLE
Added documentation of ``json::`` and ``file::`` prefixes for *es* parameters

### DIFF
--- a/doc/api/source/es.rst
+++ b/doc/api/source/es.rst
@@ -108,7 +108,7 @@ Some parameters require JSON objects as values, which cannot be expressed as str
 
 .. sourcecode:: bash
 
-    es create /template/small-server -vm_define 'json::{"vcpus": 1, "ram": 512}'
+    es create /template/small-server -vm_define "json::{\"vcpus\": 1, \"ram\": 512}"
 
 The ``file::`` prefix followed by a path leading to the file can be used to load contents of a file as a value for a parameter.
 

--- a/doc/api/source/es.rst
+++ b/doc/api/source/es.rst
@@ -102,7 +102,15 @@ Parameters
 ----------
 
 Parameters begin with a single dash followed by the name of the parameter, then followed by a value.
-Parameters are internally translated into :http:method:`POST`/:http:method:`PUT`/:http:method:`DELETE` JSON encoded data or :http:method:`GET` query strings and send to the server.
+Parameters are internally translated into :http:method:`POST`/:http:method:`PUT`/:http:method:`DELETE` JSON encoded data or :http:method:`GET` query strings and sent to the server.
+
+Some parameters require JSON objects as values, which cannot be expressed as strings or numbers from the command line. It is possible to specify a JSON object as a value by using the ``json::`` prefix. For example, the following command will create a simple template:
+
+.. sourcecode:: bash
+
+    es create /template/small-server -vm_define 'json::{"vcpus": 1, "ram": 512}'
+
+The ``file::`` prefix followed by a path leading to the file can be used to load contents of a file as a value for a parameter.
 
 .. note:: A special parameter ``-api-key`` can be used to perform an authenticated request without the need to log in.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ Features
 - Added code to collect NIC tags via node_sysinfo API call - `#226 <https://github.com/erigones/esdc-ce/issues/226>`__
 - Added ``GET /system/stats`` API function - `#233 <https://github.com/erigones/esdc-ce/issues/233>`__
 - Added ability to reset VM status back to ``notcreated`` when VM does not exist on compute node - `#248 <https://github.com/erigones/esdc-ce/issues/248>`__
+- Added documentation of ``json::`` and ``file::`` prefixes for *es* parameters - `esdc-docs#23 <https://github.com/erigones/esdc-docs/issues/23>`__
 
 Bugs
 ----


### PR DESCRIPTION
Closes erigones/esdc-docs#23