### PR TITLE
Document hidden delete methods

### DIFF
--- a/api/dns/record/api_views.py
+++ b/api/dns/record/api_views.py
@@ -57,6 +57,8 @@ class RecordView(APIView):
             qs = self.domain.record_set.select_related('domain').order_by(*self.order_by)
 
             if records is None:
+                if request.method == 'DELETE':
+                    raise InvalidInput('Invalid records')
                 self.record = qs
             else:
                 if not isinstance(records, (tuple, list)):

--- a/api/dns/record/views.py
+++ b/api/dns/record/views.py
@@ -11,7 +11,7 @@ __all__ = ('dns_record_list', 'dns_record')
 def dns_record_list(request, name, data=None):
     """
     List (:http:get:`GET </dns/domain/(name)/record>`) all DNS records which belong to a DNS domain.
-    Delete (:http:delete:`DELETE </dns/domain/(name)/record>`) all DNS records which belong to a DNS domain.
+    Delete (:http:delete:`DELETE </dns/domain/(name)/record>`) specified DNS records that belong to a DNS domain.
 
     .. http:get:: /dns/domain/(name)/record
 
@@ -22,6 +22,8 @@ def dns_record_list(request, name, data=None):
             * |DnsAdmin| or |DomainOwner|
         :Asynchronous?:
             * |async-no|
+        :arg name: **required** - Domain name
+        :type name: string
         :arg data.full: Return list of objects with all record details (default: false)
         :type data.full: boolean
         :arg data.order_by: :ref:`Available fields for sorting <order_by>`: ``id``, ``name``, ``type``, ``ttl``, \
@@ -39,10 +41,14 @@ def dns_record_list(request, name, data=None):
             * |DnsAdmin| or |DomainOwner|
         :Asynchronous?:
             * |async-no|
+        :arg name: **required** - Domain name
+        :type name: string
         :arg data.records: **required** List of DNS record ids to be deleted
-        :type data.records: list
+        :type data.records: array
         :status 200: SUCCESS
+        :status 400: FAILURE
         :status 403: Forbidden
+        :status 404: Domain not found / Record not found
         :status 412: Invalid records
     """
     if request.method == 'POST':

--- a/api/dns/record/views.py
+++ b/api/dns/record/views.py
@@ -11,6 +11,7 @@ __all__ = ('dns_record_list', 'dns_record')
 def dns_record_list(request, name, data=None):
     """
     List (:http:get:`GET </dns/domain/(name)/record>`) all DNS records which belong to a DNS domain.
+    Delete (:http:delete:`DELETE </dns/domain/(name)/record>`) all DNS records which belong to a DNS domain.
 
     .. http:get:: /dns/domain/(name)/record
 
@@ -28,6 +29,21 @@ def dns_record_list(request, name, data=None):
         :type data.order_by: string
         :status 200: SUCCESS
         :status 403: Forbidden
+
+    .. http:delete:: /dns/domain/(name)/record
+
+        :DC-bound?:
+            * |dc-yes| - ``domain.dc_bound=true``
+            * |dc-no| - ``domain.dc_bound=false``
+        :Permissions:
+            * |DnsAdmin| or |DomainOwner|
+        :Asynchronous?:
+            * |async-no|
+        :arg data.records: **required** List of DNS record ids to be deleted
+        :type data.records: list
+        :status 200: SUCCESS
+        :status 403: Forbidden
+        :status 412: Invalid records
     """
     if request.method == 'POST':
         return dns_record(request, name, 0, data=data)

--- a/api/network/ip/api_views.py
+++ b/api/network/ip/api_views.py
@@ -57,6 +57,10 @@ class NetworkIPView(APIView):
 
                 ip_filter.append(Q(ip__in=ips))
 
+            else:
+                if request.method == 'DELETE':
+                    raise InvalidInput('Invalid ips')
+
             if request.method == 'GET':
                 usage = data.get('usage', None)
 

--- a/api/network/ip/views.py
+++ b/api/network/ip/views.py
@@ -10,6 +10,7 @@ __all__ = ('net_ip_list', 'net_ip', 'subnet_ip_list')
 def net_ip_list(request, name, data=None):
     """
     List (:http:get:`GET </network/(name)/ip>`) all IP addresses in a network (name).
+    Delete (:http:delete:`DELETE </network/(name)/ip>`) list (data.ips) of IP addresses in the network (name).
 
     .. http:get:: /network/(name)/ip
 
@@ -46,12 +47,13 @@ def net_ip_list(request, name, data=None):
             * |async-no|
         :arg name: **required** - Network name
         :type name: string
-        :arg data.ips: **required** List of IPs to be deleted.
-        :type data.ips: list
+        :arg data.ips: **required** List of IPs to be deleted
+        :type data.ips: array
         :status 200: SUCCESS
         :status 403: Forbidden
-        :status 404: Network not found
-        :status 412: Invalid ips
+        :status 404: Network not found / IP address not found
+        :status 412: Invalid ips / Invalid ips value
+        :status 428: IP address is used by VM / IP address is used by Compute node
     """
     return NetworkIPView(request, name, None, data, many=True).response()
 

--- a/api/network/ip/views.py
+++ b/api/network/ip/views.py
@@ -33,6 +33,25 @@ def net_ip_list(request, name, data=None):
         :status 403: Forbidden
         :status 404: Network not found
         :status 412: Invalid usage
+
+    .. http:delete:: /network/(name)/ip
+
+        :DC-bound?:
+            * |dc-yes| - ``dc_bound=true``
+            * |dc-no| - ``dc_bound=false``
+        :Permissions:
+            * |NetworkAdmin| - ``dc_bound=true``
+            * |SuperAdmin| - ``dc_bound=false``
+        :Asynchronous?:
+            * |async-no|
+        :arg name: **required** - Network name
+        :type name: string
+        :arg data.ips: **required** List of IPs to be deleted.
+        :type data.ips: list
+        :status 200: SUCCESS
+        :status 403: Forbidden
+        :status 404: Network not found
+        :status 412: Invalid ips
     """
     return NetworkIPView(request, name, None, data, many=True).response()
 

--- a/api/vm/backup/views.py
+++ b/api/vm/backup/views.py
@@ -253,6 +253,7 @@ creating backup snapshot (requires QEMU Guest Agent) (default: false)
 def vm_backup_list(request, hostname_or_uuid, data=None):
     """
     List (:http:get:`GET </vm/(hostname_or_uuid)/backup>`) all VM backups.
+    Delete (:http:delete:`DELETE </vm/(hostname_or_uuid)/backup>`) VM backups specified by the list (data.bkpnames).
 
     .. http:get:: /vm/(hostname_or_uuid)/backup
 
@@ -284,14 +285,17 @@ def vm_backup_list(request, hostname_or_uuid, data=None):
         :Permissions:
             * |VmOwner|
         :Asynchronous?:
-            * |async-no|
+            * |async-yes|
         :arg hostname_or_uuid: **required** - Original server hostname or uuid
         :type hostname_or_uuid: string
-        :arg data.bkpnames: **required** - List of backups to be deleted.
-        :type data.bkpnames: list
+        :arg data.bkpnames: **required** - List of backups to be deleted
+        :type data.bkpnames: array
         :status 200: SUCCESS
         :status 403: Forbidden
+        :status 404: Backup not found
         :status 412: Invalid bkpnames
+        :status 417: VM backup status is not OK
+        :status 423: Node is not operational / VM is not operational
     """
     return VmBackupList(request, hostname_or_uuid, data).response()
 

--- a/api/vm/backup/views.py
+++ b/api/vm/backup/views.py
@@ -276,6 +276,22 @@ def vm_backup_list(request, hostname_or_uuid, data=None):
         :status 200: SUCCESS
         :status 403: Forbidden
         :status 412: Invalid disk_id
+
+    .. http:delete:: /vm/(hostname_or_uuid)/backup
+
+        :DC-bound?:
+            * |dc-yes|
+        :Permissions:
+            * |VmOwner|
+        :Asynchronous?:
+            * |async-no|
+        :arg hostname_or_uuid: **required** - Original server hostname or uuid
+        :type hostname_or_uuid: string
+        :arg data.bkpnames: **required** - List of backups to be deleted.
+        :type data.bkpnames: list
+        :status 200: SUCCESS
+        :status 403: Forbidden
+        :status 412: Invalid bkpnames
     """
     return VmBackupList(request, hostname_or_uuid, data).response()
 

--- a/api/vm/backup/vm_backup_list.py
+++ b/api/vm/backup/vm_backup_list.py
@@ -138,7 +138,6 @@ class VmBackupList(TaskAPIView):
     # noinspection PyAttributeOutsideInit
     def delete(self):
         """Delete multiple backups"""
-        # TODO: not documented :(
         bkp_filter = filter_disk_id(None, self.bkp_filter, self.data, default=1)  # vm_disk_id instead of disk_id
         bkps, __ = get_backups(self.request, bkp_filter, self.data)   # Parse data['bkpnames']
         bkps_lost = bkps.filter(status=Backup.LOST)

--- a/api/vm/snapshot/views.py
+++ b/api/vm/snapshot/views.py
@@ -310,8 +310,7 @@ def vm_snapshot_list(request, hostname_or_uuid, data=None):
         :status 400: FAILURE
         :status 403: Forbidden
         :status 404: VM not found
-        :status 412: Invalid snapnames
-        :status 412: Invalid disk_id
+        :status 412: Invalid snapnames / Invalid disk_id
         :status 417: VM snapshot status is not OK
         :status 423: Node is not operational / VM is not operational
         :status 428: VM is not installed

--- a/api/vm/snapshot/views.py
+++ b/api/vm/snapshot/views.py
@@ -243,6 +243,8 @@ def vm_snapshot_list(request, hostname_or_uuid, data=None):
     List (:http:get:`GET </vm/(hostname_or_uuid)/snapshot>`) all VM snapshots or
     synchronize (:http:put:`PUT </vm/(hostname_or_uuid)/snapshot>`) snapshots of VM's disk on compute node
     with snapshots saved in database.
+    Delete (:http:delete:`DELETE </vm/(hostname_or_uuid)/snapshot>`) VM snapshots specified
+    by the list (data.snapnames).
 
     .. http:get:: /vm/(hostname_or_uuid)/snapshot
 
@@ -302,13 +304,15 @@ def vm_snapshot_list(request, hostname_or_uuid, data=None):
         :arg hostname_or_uuid: **required** - Server hostname or uuid
         :type hostname_or_uuid: string
         :arg data.snapnames: **required** - List of snapshot names to be deleted
-        :type data.snapnames: list
+        :type data.snapnames: array
         :status 200: SUCCESS
         :status 201: PENDING
         :status 400: FAILURE
         :status 403: Forbidden
         :status 404: VM not found
         :status 412: Invalid snapnames
+        :status 412: Invalid disk_id
+        :status 417: VM snapshot status is not OK
         :status 423: Node is not operational / VM is not operational
         :status 428: VM is not installed
     """

--- a/api/vm/snapshot/views.py
+++ b/api/vm/snapshot/views.py
@@ -291,6 +291,26 @@ def vm_snapshot_list(request, hostname_or_uuid, data=None):
         :status 423: Node is not operational / VM is not operational
         :status 428: VM is not installed
 
+    .. http:delete:: /vm/(hostname_or_uuid)/snapshot
+
+        :DC-bound?:
+            * |dc-yes|
+        :Permissions:
+            * |VmOwner|
+        :Asynchronous?:
+            * |async-yes|
+        :arg hostname_or_uuid: **required** - Server hostname or uuid
+        :type hostname_or_uuid: string
+        :arg data.snapnames: **required** - List of snapshot names to be deleted
+        :type data.snapnames: list
+        :status 200: SUCCESS
+        :status 201: PENDING
+        :status 400: FAILURE
+        :status 403: Forbidden
+        :status 404: VM not found
+        :status 412: Invalid snapnames
+        :status 423: Node is not operational / VM is not operational
+        :status 428: VM is not installed
     """
     return VmSnapshotList(request, hostname_or_uuid, data).response()
 

--- a/api/vm/snapshot/vm_snapshot_list.py
+++ b/api/vm/snapshot/vm_snapshot_list.py
@@ -58,7 +58,6 @@ class VmSnapshotList(APIView):
 
     def delete(self):
         """Delete multiple snapshots"""
-        # TODO: not documented
         request, data, vm = self.request, self.data, self.vm
 
         disk_id, real_disk_id, zfs_filesystem = get_disk_id(request, vm, data)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Bugs
 ----
 
 - Fixed allowed_ips type on all occurrences to list instead of set to enable JSON serialization - `#242 <https://github.com/erigones/esdc-ce/issues/242>`__
+- Documented and implemented hidden DELETE methods for snapshot, backup, DNS records, and IP list API calls - `#237 <https://github.com/erigones/esdc-ce/issues/237>`__
 
 
 2.6.3 (released on 2017-08-21)


### PR DESCRIPTION
Implemented and documented DELETE method for DNS records and IPs,
that is similar to the snapshot and backup DELETE list method.

Related to #237 