### PR TITLE
Added config to customize rabbitmq-server systemd service

### DIFF
--- a/ans/upgrade/mgmt/v2.6.4/files/custom.conf
+++ b/ans/upgrade/mgmt/v2.6.4/files/custom.conf
@@ -1,0 +1,2 @@
+[Service]
+Restart=on-failure

--- a/ans/upgrade/mgmt/v2.6.4/main.yml
+++ b/ans/upgrade/mgmt/v2.6.4/main.yml
@@ -13,3 +13,20 @@
     DJANGO_SETTINGS_MODULE: "core.settings"
   register: internal_images_update_result
   changed_when: "'Updated image' in internal_images_update_result.stdout"
+
+- name: Create directory for custom rabbit-systemd settings
+  file: path=/etc/systemd/system/rabbitmq-server.service.d
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
+- name: Copy cusotm configuration file for rabbitmq-service
+  copy: src= {{ current_task_dir }}/files/custom.conf
+        dest=dest=/etc/systemd/system/rabbitmq-server.service.d/custom.conf
+        owner=root
+        group=root
+        mode=0644
+
+- name: Reload systemd configuration files
+  shell: systemctl daemon-reload

--- a/ans/upgrade/mgmt/v2.6.4/main.yml
+++ b/ans/upgrade/mgmt/v2.6.4/main.yml
@@ -22,11 +22,9 @@
         state=directory
 
 - name: Copy cusotm configuration file for rabbitmq-service
-  copy: src= {{ current_task_dir }}/files/custom.conf
-        dest=dest=/etc/systemd/system/rabbitmq-server.service.d/custom.conf
+  copy: src="{{ current_task_dir }}/files/custom.conf"
+        dest=/etc/systemd/system/rabbitmq-server.service.d/custom.conf
         owner=root
         group=root
         mode=0644
-
-- name: Reload systemd configuration files
-  shell: systemctl daemon-reload
+  notify: reload systemd


### PR DESCRIPTION
rabbitmq-server will be restarted automatically if it fails
This is related to issue erigones/esdc-factory#71