### PR TITLE
Do not highlight backups that were clicked on

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,8 @@ Features
 Bugs
 ----
 
+- Fixed highlighting of backups clicked on in the node's backup list - `#260 <https://github.com/erigones/esdc-ce/issues/260>`__
+
 
 2.6.4 (released on 2017-09-11)
 ==============================

--- a/gui/templates/gui/node/backup_list_all.html
+++ b/gui/templates/gui/node/backup_list_all.html
@@ -22,7 +22,7 @@
     <tr data-disk_id="{{ disk_id }}" data-disk_size="{{ disk_size }}" data-snapname="{{ bkp.name }}" data-status="{{ bkp.status }}" data-hostname="{{ bkp.vm_hostname }}" data-type="{{ bkp.type }}">
       <td class="top chbox hidden-phone-small"></td>
       <td>
-        <a href="{{ node_vm_backup_url }}&hostname={% if bkp.vm %}{{ bkp.vm.hostname }}{% else %}novm{% endif %}&last_bkpid={{ bkp.bkpid }}" class="btn-link" data-backup="true" title="{% trans "Edit backups for this server" %}" data-toggle="tooltip" data-placement="bottom">{{ bkp.name }}</a>
+        <a href="{{ node_vm_backup_url }}&hostname={% if bkp.vm %}{{ bkp.vm.hostname }}{% else %}novm{% endif %}" class="btn-link" data-backup="true" title="{% trans "Edit backups for this server" %}" data-toggle="tooltip" data-placement="bottom">{{ bkp.name }}</a>
       </td>
       <td><span class="vm_hostname">{{ bkp.vm_hostname }}<br><i class="icon-cloud"></i> {{ bkp.dc.alias }}</span></td>
       <td>{{ disk_id }} <small>({{ disk_size|multiply:1048576|filesizeformat }})</small></td>


### PR DESCRIPTION
When clicked on a specific backup in the Node->Backup view, in the next screen we were highlighting the backup that the user has clicked on in the previous screen. This was implemented using the `last_bkpid` query_string, which is used for another purposes (highlighting a backup that was last created). 