### PR TITLE
Disabled cloud-init network configuration in internal mgmt and mon VMs

### DIFF
--- a/ans/upgrade/mgmt/v2.6.5/files/cloud.cfg
+++ b/ans/upgrade/mgmt/v2.6.5/files/cloud.cfg
@@ -1,0 +1,28 @@
+datasource_list: [ SmartOS ]
+
+disable_root: 0
+ssh_pwauth:   1
+ssh_deletekeys: 0
+
+cloud_init_modules:
+ - growpart
+ - resizefs
+ - ssh
+
+cloud_config_modules:
+ - set-passwords
+
+network:
+  config: disabled
+
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+system_info:
+  distro: rhel
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd

--- a/ans/upgrade/mgmt/v2.6.5/main.yml
+++ b/ans/upgrade/mgmt/v2.6.5/main.yml
@@ -1,29 +1,10 @@
 #
 # https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos
 #
-- name: Fix parsing of network interfaces
-  lineinfile: dest="/etc/rc.d/rc.local"
-              regexp="^interfaces=\"\$\(ifconfig -a | grep \^eth | awk -F':' \'{print \$1}\'\)\""
-              line="interfaces=\"$(ifconfig -a | grep -E \'^eth|^net\' | awk -F':' \'{print $1}\')\""
-
-- name: Make /etc/rc.d/rc.local executable
-  file: path=/etc/rc.d/rc.local
-        owner=root
-        group=root
-        mode=0755
-
-- name: Fix firewall rules (eth0 -> net0)
-  lineinfile:
-    dest=/etc/sysconfig/iptables
-    state=present
-    insertafter='^-A INPUT -m state --state NEW'
-    line='{{ item }}'
-  with_items:
-    - '-A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -i net0 -j ACCEPT'
-    - '-A INPUT -m state --state NEW -m tcp -p tcp --dport 5672 -i net0 -j ACCEPT'
-    - '-A INPUT -m state --state NEW -m tcp -p tcp --dport 6379 -i net0 -j ACCEPT'
-    - '-A INPUT -m state --state NEW -m tcp -p tcp --dport 6432 -i net0 -j ACCEPT'
-    - '-A INPUT -m state --state NEW -m tcp -p tcp --dport 10050 -i net0 -j ACCEPT'
+- name: Disable cloud-init network configuration
+  copy: src="{{ current_task_dir }}/files/cloud.cfg"
+        dest="/etc/cloud/cloud.cfg"
+        mode=0644
 
 # https://github.com/erigones/esdc-factory/pull/73
 # https://github.com/erigones/esdc-factory/pull/79

--- a/ans/upgrade/mon/v2.6.5/files/cloud.cfg
+++ b/ans/upgrade/mon/v2.6.5/files/cloud.cfg
@@ -1,0 +1,1 @@
+../../../mgmt/v2.6.5/files/cloud.cfg

--- a/ans/upgrade/mon/v2.6.5/main.yml
+++ b/ans/upgrade/mon/v2.6.5/main.yml
@@ -1,16 +1,10 @@
 #
 # https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos
 #
-- name: Fix parsing of network interfaces
-  lineinfile: dest="/etc/rc.d/rc.local"
-              regexp="^interfaces=\"\$\(ifconfig -a | grep \^eth | awk -F':' \'{print \$1}\'\)\""
-              line="interfaces=\"$(ifconfig -a | grep -E \'^eth|^net\' | awk -F':' \'{print $1}\')\""
-
-- name: Make /etc/rc.d/rc.local executable
-  file: path=/etc/rc.d/rc.local
-        owner=root
-        group=root
-        mode=0755
+- name: Disable cloud-init network configuration
+  copy: src="{{ current_task_dir }}/files/cloud.cfg"
+        dest="/etc/cloud/cloud.cfg"
+        mode=0644
 
 - name: Load Zabbix credentials
   include: "{{ upg_base }}/lib/zabbix_credentials.yml"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,7 +17,7 @@ Bugs
 - Restricted dc_bound API calls to require datacenter to be explicitly set via dc parameter - `#265 <https://github.com/erigones/esdc-ce/issues/265>`__
 - Fixed highlighting of backups clicked on in the node's backup list - `#260 <https://github.com/erigones/esdc-ce/issues/260>`__
 - Fixed Super admin delete user and got error 500 - `#263 <https://github.com/erigones/esdc-ce/issues/263>`__
-- Fixed NIC discovery in mgmt and mon VMs - `#270 <https://github.com/erigones/esdc-ce/issues/270>`__
+- Disabled cloud-init network configuration in mgmt and mon VMs - `#270 <https://github.com/erigones/esdc-ce/issues/270>`__ + `#276 <https://github.com/erigones/esdc-ce/issues/276>`__ 
 - Fixed VM stop and reboot actions in compute node's server list - `#275 <https://github.com/erigones/esdc-ce/issues/275>`__
 
 


### PR DESCRIPTION
Related to https://github.com/erigones/esdc-ce/pull/270 and https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos