### PR TITLE
Updated the VM templates API + removed *experimental* flag from the `template_manage` API call

### DIFF
--- a/api/image/base/views.py
+++ b/api/image/base/views.py
@@ -160,7 +160,7 @@ image server support is disabled in the system
     .. http:delete:: /image/(name)
 
         .. note:: A server disk image cannot be deleted when it is used by even one virtual server. In order to \
-disable further use of such a disk image the image can be marked as deleted by \
+disable further use of such a disk image, the image can be marked as deleted by \
 :http:put:`changing its access property to deleted (4) </image/(name)>`.
 
         :DC-bound?:

--- a/api/image/base/views.py
+++ b/api/image/base/views.py
@@ -159,6 +159,10 @@ image server support is disabled in the system
 
     .. http:delete:: /image/(name)
 
+        .. note:: A server disk image cannot be deleted when it is used by even one virtual server. In order to \
+disable further use of such a disk image the image can be marked as deleted by \
+:http:put:`changing its access property to deleted (4) </image/(name)>`.
+
         :DC-bound?:
             * |dc-yes| - ``dc_bound=true``
             * |dc-no| - ``dc_bound=false``

--- a/api/network/base/views.py
+++ b/api/network/base/views.py
@@ -162,6 +162,10 @@ def net_manage(request, name, data=None):
 
     .. http:delete:: /network/(name)
 
+        .. note:: A virtual network cannot be deleted when it is used by even one virtual server. In order to \
+disable further use of such a virtual network the network can be marked as deleted by \
+:http:put:`changing its access property to deleted (4) </network/(name)>`.
+
         :DC-bound?:
             * |dc-yes| - ``dc_bound=true``
             * |dc-no| - ``dc_bound=false``

--- a/api/network/base/views.py
+++ b/api/network/base/views.py
@@ -163,7 +163,7 @@ def net_manage(request, name, data=None):
     .. http:delete:: /network/(name)
 
         .. note:: A virtual network cannot be deleted when it is used by even one virtual server. In order to \
-disable further use of such a virtual network the network can be marked as deleted by \
+disable further use of such a virtual network, the network can be marked as deleted by \
 :http:put:`changing its access property to deleted (4) </network/(name)>`.
 
         :DC-bound?:

--- a/api/template/base/serializers.py
+++ b/api/template/base/serializers.py
@@ -145,7 +145,22 @@ class TemplateSerializer(s.ConditionalDCBoundSerializer):
 
             if limit is not None:
                 if VmTemplate.objects.filter(dc_bound=self._dc_bound).count() >= int(limit):
-                    raise s.ValidationError(_('Maximum number of server templates reached'))
+                    raise s.ValidationError(_('Maximum number of server templates reached.'))
+
+        try:
+            ostype = attrs['ostype']
+        except KeyError:
+            ostype = self.object.ostype
+
+        try:
+            vm_define = attrs['vm_define']
+        except KeyError:
+            vm_define = self.object.vm_define
+
+        vm_define_ostype = vm_define.get('ostype', None)
+
+        if vm_define_ostype is not None and ostype != vm_define_ostype:
+            raise s.ValidationError('Mismatch between vm_define ostype and template ostype.')
 
         return super(TemplateSerializer, self).validate(attrs)
 

--- a/api/template/base/serializers.py
+++ b/api/template/base/serializers.py
@@ -159,6 +159,10 @@ class TemplateSerializer(s.ConditionalDCBoundSerializer):
 
         vm_define_ostype = vm_define.get('ostype', None)
 
+        # The template object itself has an ostype field, which is used to limit the use of a template on the DB level;
+        # However, also the template.vm_define property can have an ostype attribute, which will be used for a new VM
+        # (=> will be inherited from the template). A different ostype in both places will lead to strange situations
+        # (e.g. using a Windows template, which will create a Linux VM). Therefore we have to prevent such situations.
         if vm_define_ostype is not None and ostype != vm_define_ostype:
             raise s.ValidationError('Mismatch between vm_define ostype and template ostype.')
 

--- a/api/template/base/views.py
+++ b/api/template/base/views.py
@@ -157,7 +157,7 @@ in a virtual datacenter).
     .. http:delete:: /template/(name)
 
         .. note:: A server template cannot be deleted when it is used by even one virtual server. In order to disable \
-further use of such a server template the template can be marked as deleted by \
+further use of such a server template, the template can be marked as deleted by \
 :http:put:`changing its access property to deleted (4) </template/(name)>`.
 
         :DC-bound?:

--- a/api/template/base/views.py
+++ b/api/template/base/views.py
@@ -39,7 +39,10 @@ def template_manage(request, name, data=None):
     update (:http:put:`PUT </template/(name)>`) or delete (:http:delete:`DELETE </template/(name)>`)
     a server template.
 
-    .. warning:: EXPERIMENTAL API function.
+    .. note:: Server templates are only loosely validated during creation and updating. Whether a server template \
+will be correctly applied to a virtual server depends on various circumstances during server definition and deployment \
+(e.g. availability of compute nodes, storages, networks, server images, users and other resources \
+in a virtual datacenter).
 
     .. http:get:: /template/(name)
 
@@ -152,6 +155,10 @@ def template_manage(request, name, data=None):
         :status 404: Template not found
 
     .. http:delete:: /template/(name)
+
+        .. note:: A server template cannot be deleted when it is used by even one virtual server. In order to disable \
+further use of such a server template the template can be marked as deleted by \
+:http:put:`changing its access property to deleted (4) </template/(name)>`.
 
         :DC-bound?:
             * |dc-yes| - ``dc_bound=true``

--- a/doc/api/source/api/template_base.rst
+++ b/doc/api/source/api/template_base.rst
@@ -11,3 +11,52 @@
 
 .. autofunction:: api.template.base.views.template_manage
 
+
+    |es example|:
+
+    .. sourcecode:: bash
+
+        es create /template/linux-small1 -ostype 1 -vm_define 'json::{"vcpus": 1, "ram":512}' -vm_define_disk 'json::[{"size": "10240"}]' -vm_define_snapshot 'json::[{"name": "hourly", "disk_id": 1, "retention": 48, "desc": "Automatic hourly snapshot of 1st disk"}]'
+
+    .. sourcecode:: json
+
+        {
+            "url": "https://my.erigones.com/api/template/linux-small1/",
+            "status": 201,
+            "method": "POST",
+            "text": {
+                "status": "SUCCESS",
+                "result": {
+                    "vm_define_snapshot": [
+                        {
+                            "desc": "Automatic hourly snapshot of 1st disk",
+                            "name": "hourly",
+                            "disk_id": 1,
+                            "retention": 48
+                        }
+                    ],
+                    "name": "linux-small1",
+                    "created": "2016-11-11T15:15:16.079537Z",
+                    "vm_define_backup": [],
+                    "access": 3,
+                    "alias": "linux-small1",
+                    "dc_bound": false,
+                    "vm_define_disk": [
+                        {
+                            "size": "10240"
+                        }
+                    ],
+                    "vm_define_disk": [],
+                    "ostype": 1,
+                    "owner": "admin",
+                    "vm_define_nic": [],
+                    "vm_define": {
+                        "vcpus": 1,
+                        "ram": 512
+                    },
+                    "desc": ""
+                },
+                "task_id": "1d1u23-6f75849b-f4a3-4c29-8fd9"
+            }
+        }
+

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ Features
 - Monitoring hostgroups are either datacenter-based or global - `#93 <https://github.com/erigones/esdc-ce/issues/93>`__
 - Monitoring hostgroups are automatically created on VM and Node update if they don't exist - `#93 <https://github.com/erigones/esdc-ce/issues/93>`__
 - DC settings implied monitoring hostgroups are shown near the VM, node monitoring_hostgroups setting- `#266 <https://github.com/erigones/esdc-ce/issues/266>`__
+- Updated the VM templates API + removed *experimental* flag from the ``template_manage`` API call - `#256 <https://github.com/erigones/esdc-ce/issues/256>`__
 
 Bugs
 ----


### PR DESCRIPTION

Closes #256

- Checking for possible mismatch between ``template.ostype`` and ``template.vm_define.ostype``.
- Added note about removing used templates, networks and disk images.
- Added example for ``POST /template/(name)`` into the API documentation.