### PR TITLE
Fixed race condition in get_or_create_hostgroups()

### DIFF
--- a/api/mon/backends/zabbix/base.py
+++ b/api/mon/backends/zabbix/base.py
@@ -948,7 +948,7 @@ class ZabbixNamedContainer(object):
             return zapi.call(zapi_method, params=params)
         except ZabbixAPIError as exc:
             data = exc.error.get('data')
-            if data and 'already exists' in data:
+            if data and ('already exists' in data or 'SQL statement execution has failed "INSERT INTO' in data):
                 exc = RemoteObjectAlreadyExists(**exc.error)
             raise exc
 

--- a/api/mon/backends/zabbix/external.py
+++ b/api/mon/backends/zabbix/external.py
@@ -39,11 +39,11 @@ class ExternalZabbix(ZabbixBase):
         hostgroups = set(self.settings.MON_ZABBIX_HOSTGROUPS_VM)
         hostgroups.update(vm.monitoring_hostgroups)
 
-        return self._get_or_create_groups(self._vm_kwargs(vm),
-                                          self.settings.MON_ZABBIX_HOSTGROUP_VM,
-                                          vm.dc.name,
-                                          hostgroups,
-                                          log)
+        return self._get_or_create_hostgroups(self._vm_kwargs(vm),
+                                              self.settings.MON_ZABBIX_HOSTGROUP_VM,
+                                              vm.dc.name,
+                                              hostgroups,
+                                              log)
 
     def _vm_templates(self, vm, log=None):
         """Return set of zabbix template IDs for a VM"""

--- a/api/mon/backends/zabbix/internal.py
+++ b/api/mon/backends/zabbix/internal.py
@@ -27,11 +27,11 @@ class InternalZabbix(ZabbixBase):
     # noinspection PyProtectedMember
     def _vm_groups(self, vm, log=None):
         """Return set of zabbix hostgroup IDs for a VM"""
-        return self._get_or_create_groups(self._vm_kwargs(vm),
-                                          django_settings._MON_ZABBIX_HOSTGROUP_VM,
-                                          vm.dc.name,
-                                          django_settings._MON_ZABBIX_HOSTGROUPS_VM,
-                                          log)
+        return self._get_or_create_hostgroups(self._vm_kwargs(vm),
+                                              django_settings._MON_ZABBIX_HOSTGROUP_VM,
+                                              vm.dc.name,
+                                              django_settings._MON_ZABBIX_HOSTGROUPS_VM,
+                                              log)
 
     def _node_groups(self, node, log=None):
         """Return set of zabbix hostgroup IDs for a Compute node"""
@@ -39,11 +39,11 @@ class InternalZabbix(ZabbixBase):
         hostgroups.update(node.monitoring_hostgroups)
         empty_prefix = ''
 
-        return self._get_or_create_groups(self._node_kwargs(node),
-                                          self.settings.MON_ZABBIX_HOSTGROUP_NODE,
-                                          empty_prefix,
-                                          hostgroups,
-                                          log)
+        return self._get_or_create_hostgroups(self._node_kwargs(node),
+                                              self.settings.MON_ZABBIX_HOSTGROUP_NODE,
+                                              empty_prefix,
+                                              hostgroups,
+                                              log)
 
     # noinspection PyProtectedMember
     def _vm_templates(self, vm, log=None):

--- a/core/settings.py
+++ b/core/settings.py
@@ -405,6 +405,7 @@ SYSTEM_USER = 7
 SYSTEM_USERNAME = '_system'
 
 API_SYNC_TIMEOUT = 3600
+API_LOCK_TIMEOUT = 300
 
 SHADOW_EMAIL = ''  # bcc for every outgoing email
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ Bugs
 ----
 
 - Added missing DNS record for ns1.local after install - `#301 <https://github.com/erigones/esdc-ce/issues/301>`__
+- Fixed race condition in Zabbix host group manipulation - `#309 <https://github.com/erigones/esdc-ce/issues/309>`__
 
 
 2.6.7 (released on 2017-11-06)


### PR DESCRIPTION
Related to #210 

- Renamed _get_or_create_groups() -> _get_or_create_hostgroups()
- Added RemoteObjectAlreadyExists exception
- Switched to RemoteObjectDoesNotExist in proper places (backward compatible)
- Added ZabbixUserGroupContainer.get()
- Fixed get_template_list() and get_hostgroup_list()