### PR TITLE
Remove reference to non-existing setting `VMS_NET_NIC_TAGS` in DC setting in GUI

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ Bugs
 ----
 
 - Added missing DNS record for ns1.local after install - `#301 <https://github.com/erigones/esdc-ce/issues/301>`__
+- Removed reference to non-existing ``VMS_NET_NIC_TAGS`` setting in GUI - `#310 <https://github.com/erigones/esdc-ce/issues/310>`__
 
 
 2.6.7 (released on 2017-11-06)

--- a/gui/templates/gui/dc/dc_settings_table.html
+++ b/gui/templates/gui/dc/dc_settings_table.html
@@ -51,7 +51,6 @@
 
 {% if all %}
 <tr><td colspan="2" class="row-header"><i class="icon-sitemap"></i> {% trans "Compute nodes" %}</td></tr>
-{% include "gui/table_form_field.html" with field=form.VMS_NET_NIC_TAGS trclass="setting" %}
 {% include "gui/table_form_field.html" with field=form.VMS_NODE_SSH_KEYS_DEFAULT trclass="setting" %}
 {% endif %}
 


### PR DESCRIPTION
Related to #267