### PR TITLE
Added upgrade scripts for SSL on internal/admin services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ pip-log.txt
 .DS_Store
 *.swp
 *.test
+*.bkp
 
 # Celery
 celerybeat-schedule*

--- a/ans/upgrade/cfgdb/v3.0.0/files/cfgdb-zk-rest.xml
+++ b/ans/upgrade/cfgdb/v3.0.0/files/cfgdb-zk-rest.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='cfgdb-zk-rest'>
+    <service name='application/cfgdb-zk-rest' type='service' version='0'>
+        <create_default_instance enabled='false' />
+        <single_instance />
+        <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+            <service_fmri value='svc:/milestone/network:default' />
+        </dependency>
+        <dependency name='filesystem' grouping='require_all' restart_on='error' type='service'>
+            <service_fmri value='svc:/system/filesystem/local' />
+        </dependency>
+        <exec_method name='start' type='method' exec='/usr/local/bin/cfgdb_zk_rest_server.py &amp;' timeout_seconds='60'>
+            <method_context>
+                <method_credential group='nobody' user='nobody' />
+                <method_environment>
+                    <envvar name='PATH' value='/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />
+                    <envvar name='ZK_REST_HTTP_SSL_CERT' value='/usr/local/etc/zk_rest_http_ssl.crt' />
+                    <envvar name='ZK_REST_HTTP_SSL_KEY' value='/usr/local/etc/zk_rest_http_ssl.key' />
+                </method_environment>
+            </method_context>
+        </exec_method>
+        <exec_method name='stop' type='method' exec=':kill' timeout_seconds='10' />
+        <property_group name='startd' type='framework'>
+            <propval name='duration' type='astring' value='contract' />
+            <propval name='ignore_error' type='astring' value='core,signal' />
+        </property_group>
+        <template>
+            <common_name>
+                <loctext xml:lang='C'>Danube Cloud cfgdb ZooKeeper REST service</loctext>
+            </common_name>
+        </template>
+    </service>
+</service_bundle>

--- a/ans/upgrade/cfgdb/v3.0.0/files/cfgdb_zk_rest_server.py
+++ b/ans/upgrade/cfgdb/v3.0.0/files/cfgdb_zk_rest_server.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import ssl
+import json
+import signal
+import logging
+import subprocess
+
+try:
+    # noinspection PyCompatibility,PyUnresolvedReferences
+    import urlparse
+except ImportError:
+    # noinspection PyCompatibility,PyUnresolvedReferences
+    from urllib import parse as urlparse
+
+try:
+    # noinspection PyCompatibility,PyUnresolvedReferences
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+except ImportError:
+    # noinspection PyCompatibility,PyUnresolvedReferences
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PY3 = sys.version_info[0] >= 3
+
+if PY3:
+    string_types = (str,)
+else:
+    # noinspection PyUnresolvedReferences
+    string_types = (basestring,)
+
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)-8s %(name)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+VERSION = '0.1'
+DEFAULT_HTTP_ADDRESS = ''
+DEFAULT_HTTP_PORT = 12181
+
+
+class ValidationError(ValueError):
+    def __init__(self, attr, detail, status=400):
+        self.attr = attr
+        self.detail = detail
+        self.status = status
+
+    @property
+    def as_json(self):
+        return {self.attr: self.detail}
+
+
+# noinspection PyPep8Naming
+class RESTRequestHandler(BaseHTTPRequestHandler):
+    method = None
+
+    def send_json_response(self, data, status=200):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(data))
+
+    def parse_json_request(self):
+        content_length = int(self.headers.getheader('Content-Length', 0))
+
+        if content_length:
+            content = json.loads(self.rfile.read(content_length))
+        else:
+            content = {}
+
+        return content
+
+    def handle_request(self):
+        raise NotImplementedError
+
+    def _handle_request(self):
+        try:
+            self.handle_request()
+        except ValidationError as exc:
+            self.send_json_response(exc.as_json, status=exc.status)
+        except Exception as exc:
+            logger.exception(exc)
+            self.send_error(500, 'Internal Server Error')
+
+    def do_GET(self):
+        self.method = 'GET'
+        self._handle_request()
+
+    def do_POST(self):
+        self.method = 'POST'
+        self._handle_request()
+
+    def do_PUT(self):
+        self.method = 'PUT'
+        self._handle_request()
+
+    def do_DELETE(self):
+        self.method = 'DELETE'
+        self._handle_request()
+
+
+class ZKRESTRequestHandler(RESTRequestHandler):
+    default_string_max_length = 4019
+    zk_data_size_limit = 2097152
+    zk_commands = frozenset((
+        'exists',
+        'get',
+        'ls',
+        'lsr',
+        'create',
+        'creater',
+        'set',
+        'delete',
+        'rm',
+        'deleter',
+        'rmr',
+        'getacl',
+        'setacl'
+    ))
+    method_to_zk_command = {
+        'GET': 'get',
+        'POST': 'create',
+        'PUT': 'set',
+        'DELETE': 'delete',
+    }
+    zk_servers = os.environ.get('ZK_REST_ZK_SERVERS', '127.0.0.1')
+    zk_base_cmd = (os.environ.get('ZK_REST_ZK_CLI', 'zookeepercli'), '-servers', zk_servers)
+
+    def version_string(self):
+        return 'ZooKeeper REST Service / ' + VERSION
+
+    @classmethod
+    def validate_string_input(cls, attr, value, max_length=default_string_max_length):
+        if not isinstance(value, string_types):
+            raise ValidationError(attr, 'Invalid value.')
+
+        if max_length and len(value) > max_length:
+            raise ValidationError(attr, 'Too large.', status=413)
+
+        return value
+
+    def run_zk_cmd(self, command, node, data=None, force=False, username=None, password=None):
+        cmd = list(self.zk_base_cmd)
+
+        if force:
+            cmd.append('-force')
+
+        if username is not None:
+            cmd.extend(('-auth_usr', self.validate_string_input('username', username)))
+
+        if password is not None:
+            cmd.extend(('-auth_pwd', self.validate_string_input('password', password)))
+
+        cmd.extend(('-c', command, self.validate_string_input('node', node)))
+
+        if data is not None:
+            cmd.append(self.validate_string_input('data', data, max_length=self.zk_data_size_limit))
+
+        logger.debug('Running command: %s', cmd)
+        exc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+        stdout, stderr = exc.communicate()
+        res = {'returncode': exc.returncode, 'stdout': stdout.strip(), 'stderr': stderr.strip()}
+        logger.info('Command "%s" finished with %s', cmd, res)
+
+        return res
+
+    def handle_request(self):
+        url = urlparse.urlparse(self.path)
+        qs = urlparse.parse_qs(url.query)
+        zk_cmd = qs.get('cmd', None)
+
+        if zk_cmd:
+            zk_cmd = zk_cmd[0]
+        else:
+            zk_cmd = self.method_to_zk_command.get(self.method, None)
+
+        if not zk_cmd or zk_cmd not in self.zk_commands:
+            self.send_json_response({'detail': 'Invalid command'}, status=400)
+            return
+
+        try:
+            data = self.parse_json_request()
+
+            if not isinstance(data, dict):
+                raise TypeError
+        except (TypeError, ValueError):
+            self.send_json_response('Malformed request', status=400)
+            return
+
+        res = self.run_zk_cmd(
+            zk_cmd,
+            url.path,
+            data=data.get('data', None),
+            force=bool(data.get('force', False)),
+            username=self.headers.get('zk-username', None),
+            password=self.headers.get('zk-password', None)
+        )
+
+        if res['returncode'] == 0:
+            status = 200
+        else:
+            if 'node does not exist' in res['stderr']:
+                status = 404
+            elif 'node already exists' in res['stderr']:
+                status = 406
+            else:
+                status = 400
+
+        self.send_json_response(res, status=status)
+
+
+class ESDCZKRESTRequestHandler(ZKRESTRequestHandler):
+    def version_string(self):
+        return 'ESDC ' + ZKRESTRequestHandler.version_string(self)
+
+    def handle_request(self):
+        if self.path.startswith('/esdc/'):
+            ZKRESTRequestHandler.handle_request(self)
+        else:
+            self.send_json_response({'detail': 'Permission Denied'}, status=403)
+
+
+def run_server(address=DEFAULT_HTTP_ADDRESS, port=DEFAULT_HTTP_PORT, ssl_cert=None, ssl_key=None, ca_certs=None,
+               request_handler=ESDCZKRESTRequestHandler):
+    http_server = HTTPServer((address, port), request_handler)
+
+    if ssl_cert:
+        http_server.socket = ssl.wrap_socket(http_server.socket, keyfile=ssl_key, certfile=ssl_cert, ca_certs=ca_certs,
+                                             server_side=True)
+
+    # noinspection PyUnusedLocal
+    def stop_server(signum, frame):
+        logger.info('Stopping HTTP server with signal %s', signum)
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, stop_server)
+    signal.signal(signal.SIGTERM, stop_server)
+    logger.info('Starting HTTP [ssl=%s] server at %s:%s', ssl_cert, address, port)
+
+    try:
+        http_server.serve_forever()
+    except KeyboardInterrupt:
+        http_server.shutdown()
+
+    logger.info('Stopped HTTP server')
+    http_server.server_close()
+
+
+def main():
+    run_server(
+        address=os.environ.get('ZK_REST_HTTP_ADDRESS', DEFAULT_HTTP_ADDRESS),
+        port=os.environ.get('ZK_REST_HTTP_PORT', DEFAULT_HTTP_PORT),
+        ssl_cert=os.environ.get('ZK_REST_HTTP_SSL_CERT', None),
+        ssl_key=os.environ.get('ZK_REST_HTTP_SSL_KEY', None),
+        ca_certs=os.environ.get('ZK_REST_HTTP_CA_CERTS', None),
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/ans/upgrade/cfgdb/v3.0.0/files/query_cfgdb_local
+++ b/ans/upgrade/cfgdb/v3.0.0/files/query_cfgdb_local
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ZKCLI=/usr/local/bin/zookeepercli
+
+if [[ -z "${2}" ]]; then
+	echo "Usage:   $0 <query>" 1>&2
+	echo "Example: $0 ls /esdc/nodes" 1>&2
+	exit 10
+fi
+
+if [[ ! -x "${ZKCLI}" ]]; then
+	echo "Error: Cannot find binary ${ZKCLI}" 1>&2
+	exit 20
+fi
+
+# query cfgdb credentials
+CFGDB_USERNAME="$(mdata-get org.erigones:cfgdb_username 2>/dev/null || echo 'esdc')"
+CFGDB_PASSWORD="$(mdata-get org.erigones:cfgdb_password 2>/dev/null)"
+
+if [[ -n "${CFGDB_USERNAME}" && -n "${CFGDB_PASSWORD}" ]]; then
+	"${ZKCLI}" -servers localhost -auth_usr "${CFGDB_USERNAME}" -auth_pwd "${CFGDB_PASSWORD}" -c "${@}"
+else
+	"${ZKCLI}" -servers localhost -c "${@}"
+fi
+
+exit $?
+

--- a/ans/upgrade/cfgdb/v3.0.0/main.yml
+++ b/ans/upgrade/cfgdb/v3.0.0/main.yml
@@ -1,0 +1,83 @@
+#
+# https://github.com/erigones/esdc-factory/issues/102
+# https://github.com/erigones/esdc-factory/issues/108
+#
+- name: Copy fixed query_cfgdb local script
+  copy: src=query_cfgdb_local
+        dest=/usr/local/bin/query_cfgdb
+        owner=root
+        group=root
+        mode=0755
+
+- name: Get or create erigonesd SSL certificate (locally)
+  include: "{{ upg_base }}/lib/erigonesd_ssl.yml"
+
+- name: Check /esdc/settings/security/services_ssl_cert in ZooKeeper
+  command: /usr/local/bin/query_cfgdb get /esdc/settings/security/services_ssl_cert
+  register: zk_ssl_cert
+  ignore_errors: true
+  changed_when: zk_ssl_cert|failed or zk_ssl_cert.stdout.strip() != "{{ ERIGONESD_SSL_CERT.strip() }}"
+
+# Store striped in ZooKeeper (because zookeepercli appends a newline when reading)
+- name: Create /esdc/settings/security/services_ssl_cert in ZooKeeper
+  command: /usr/local/bin/query_cfgdb creater /esdc/settings/security/services_ssl_cert "{{ ERIGONESD_SSL_CERT.strip() }}"
+  when: zk_ssl_cert|failed
+
+- name: Update /esdc/settings/security/services_ssl_cert in ZooKeeper
+  command: /usr/local/bin/query_cfgdb set /esdc/settings/security/services_ssl_cert "{{ ERIGONESD_SSL_CERT.strip() }}"
+  when: zk_ssl_cert|succeeded and zk_ssl_cert|changed
+
+# Store raw in metadata (so we have the same metadata as on mgmt)
+- name: Set metadata for cfgdb ZK REST SSL certificate and key
+  shell: mdata-put "{{ item.key }}" "{{ item.value }}"
+  with_items:
+    - { key: "org.erigones:cfgdb_zk_rest_ssl_key", value: "{{ ERIGONESD_SSL_KEY }}" }
+    - { key: "org.erigones:cfgdb_zk_rest_ssl_cert", value: "{{ ERIGONESD_SSL_CERT }}" }
+  when: zk_ssl_cert|changed
+
+- name: Save erigonesd SSL certificate to /usr/local/etc/zk_rest_http_ssl.crt
+  copy: content="{{ ERIGONESD_SSL_CERT }}"
+        dest="/usr/local/etc/zk_rest_http_ssl.crt"
+        owner=root
+        group=root
+        mode=0644
+
+- name: Save erigonesd SSL key to /usr/local/etc/zk_rest_http_ssl.key
+  copy: content="{{ ERIGONESD_SSL_KEY }}"
+        dest="/usr/local/etc/zk_rest_http_ssl.key"
+        owner=nobody
+        group=root
+        mode=0400
+
+- name: Copy cfgdb_zk_rest_server.py script
+  copy: src=cfgdb_zk_rest_server.py
+        dest=/usr/local/bin/cfgdb_zk_rest_server.py
+        owner=root
+        group=root
+        mode=0755
+
+- name: Copy cfgdb-zk-rest SMF manifest
+  copy: src=cfgdb-zk-rest.xml
+        dest=/opt/local/lib/svc/manifest/cfgdb-zk-rest.xml
+  register: zk_rest_manifest
+
+- name: Import cfgdb-zk-rest SMF manifest
+  command: /usr/sbin/svccfg import /opt/local/lib/svc/manifest/cfgdb-zk-rest.xml
+  when: zk_rest_manifest|changed
+
+- name: Restart cfgdb-zk-rest
+  service: name=cfgdb-zk-rest
+           state=restarted
+           enabled=yes
+  when: zk_rest_manifest|changed or zk_ssl_cert|changed
+
+- name: Make sure that cfgdb-zk-rest is running
+  service: name=cfgdb-zk-rest
+           state=started
+           enabled=yes
+
+- name: Check service health
+  shell: /usr/bin/svcs -x
+  register: svcs_x
+  changed_when: false
+  failed_when: svcs_x.stdout.strip() != "" or svcs_x.stderr.strip() != ""

--- a/ans/upgrade/lib/erigonesd_ssl.yml
+++ b/ans/upgrade/lib/erigonesd_ssl.yml
@@ -1,0 +1,75 @@
+#
+# Get or create erigonesd SSL certificate and key on mgmt server.
+# https://github.com/erigones/esdc-factory/issues/102
+#
+# This will ensure that the dc-erigonesd.pem file exists on the mgmt_host
+# and will set some facts:
+#   - ERIGONESD_SSL_CERT_FILE
+#   - ERIGONESD_SSL_KEY_FILE
+#   - ERIGONESD_SSL_FILE
+#   - ERIGONESD_SSL_CERT
+#   - ERIGONESD_SSL_KEY
+#   - ERIGONESD_SSL_NEW
+#
+
+- name: Set erigonesd SSL file fact
+  set_fact:
+    ERIGONESD_SSL_CERT_FILE: "/etc/pki/tls/certs/dc-erigonesd.crt"
+    ERIGONESD_SSL_KEY_FILE: "/etc/pki/tls/certs/dc-erigonesd.key"
+    ERIGONESD_SSL_FILE: "/etc/pki/tls/certs/dc-erigonesd.pem"
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Configure openssl.cnf for generating new erigonesd SSL certificate
+  ini_file: dest="/etc/pki/tls/openssl.cnf"
+            section="SAN"
+            option="subjectAltName"
+            value="DNS:esdc.local,DNS:mgmt01.local,DNS:mgmt.local,DNS:mon01.local,DNS:mon.local,DNS:cfgdb01.local,DNS:cfgdb.local,DNS:img01.local,DNS:img.local,DNS:dns01.local,DNS:dns.local,DNS:*.local"
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Generate new erigonesd SSL key and certificate
+  shell: openssl req -x509 -sha256 -nodes -days 10000 -subj '/CN=esdc.local/O=Danube Cloud/' -reqexts SAN -extensions SAN -newkey rsa:8192 -keyout "{{ ERIGONESD_SSL_KEY_FILE }}" -out "{{ ERIGONESD_SSL_CERT_FILE }}"
+  args:
+    creates: "{{ ERIGONESD_SSL_CERT_FILE }}"
+  register: openssl_generate_cert
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Create {{ ERIGONESD_SSL_FILE }}
+  shell: cat "{{ ERIGONESD_SSL_KEY_FILE }}" "{{ ERIGONESD_SSL_CERT_FILE }}" > "{{ ERIGONESD_SSL_FILE }}"
+  args:
+    creates: "{{ ERIGONESD_SSL_FILE }}"
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Set permissions on the new erigonesd SSL file
+  file: path="{{ item }}"
+        mode=0600
+  with_items:
+    - "{{ ERIGONESD_SSL_KEY_FILE }}"
+    - "{{ ERIGONESD_SSL_FILE }}"
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Load {{ ERIGONESD_SSL_CERT_FILE }}
+  slurp: src="{{ ERIGONESD_SSL_CERT_FILE }}"
+  register: erigonesd_ssl_cert
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Load {{ ERIGONESD_SSL_KEY_FILE }}
+  slurp: src="{{ ERIGONESD_SSL_KEY_FILE }}"
+  register: erigonesd_ssl_key
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Set ERIGONESD_SSL_CERT and ERIGONESD_SSL_KEY facts
+  set_fact:
+    ERIGONESD_SSL_CERT: "{{ erigonesd_ssl_cert['content'] | b64decode }}"
+    ERIGONESD_SSL_KEY: "{{ erigonesd_ssl_key['content'] | b64decode  }}"
+    ERIGONESD_SSL_NEW: "{{ openssl_generate_cert|changed }}"
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Fail if ERIGONESD_SSL_CERT is empty
+  fail: msg="ERIGONESD_SSL_CERT is empty"
+  when: ERIGONESD_SSL_CERT == ""
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"
+
+- name: Fail if ERIGONESD_SSL_KEY is empty
+  fail: msg="ERIGONESD_SSL_KEY is empty"
+  when: ERIGONESD_SSL_KEY == ""
+  delegate_to: "{{ mgmt_host | default('127.0.0.1') }}"

--- a/ans/upgrade/lib/runupgrade.yml
+++ b/ans/upgrade/lib/runupgrade.yml
@@ -45,3 +45,5 @@
   # can't use service module because SmartOS svcadm doesn't have "-s" switch
   - name: restart pdns
     shell: /usr/sbin/svcadm disable -s svc:/pkgsrc/pdns:default && /usr/sbin/svcadm enable -s svc:/pkgsrc/pdns:default
+  - name: iptables-save
+    shell: iptables-save > /etc/sysconfig/iptables

--- a/ans/upgrade/mgmt/v3.0.0/main.yml
+++ b/ans/upgrade/mgmt/v3.0.0/main.yml
@@ -2,3 +2,72 @@
 - name: Fix /etc/rc.d/rc.local permissions
   file: dest=/etc/rc.d/rc.local
         mode=u+x
+
+#
+# https://github.com/erigones/esdc-factory/issues/102
+#
+- name: Set IP address of cfgdb
+  set_fact:
+    cfgdb_ip: "{{ hostvars['cfgdb' + inventory_hostname.lstrip('mgmt')].ansible_ssh_host|mandatory }}"
+    cfgdb_ip_mdata_key: "org.erigones:cfgdb_ip"
+
+- name: Get or create erigonesd SSL certificate (locally)
+  include: "{{ upg_base }}/lib/erigonesd_ssl.yml"
+
+- name: Read current metadata
+  shell: mdata-list
+  register: mdata_list
+  changed_when: false
+
+- name: Set metadata for new erigonesd SSL certificate and key
+  shell: mdata-put "{{ item.key }}" "{{ item.value }}"
+  with_items:
+    - { key: "org.erigones:erigonesd_ssl_key", value: "{{ ERIGONESD_SSL_KEY }}" }
+    - { key: "org.erigones:erigonesd_ssl_cert", value: "{{ ERIGONESD_SSL_CERT }}" }
+  when: ERIGONESD_SSL_NEW
+
+- name: Set metadata for cfgdb_ip
+  shell: mdata-put "{{ cfgdb_ip_mdata_key }}" "{{ cfgdb_ip }}"
+  when: cfgdb_ip_mdata_key not in mdata_list.stdout_lines
+
+- name: Add admin services proxy into haproxy.cfg
+  blockinfile:
+    dest: /etc/haproxy/haproxy.cfg
+    validate: "/usr/sbin/haproxy -c -f '%s'"
+    marker: "# {mark} Danube Cloud {{ item.name }} service proxy"
+    block: "listen {{ item.name }}\n{{ item.config|join('\n') }}\n"
+  with_items:
+    - name: rabbitmq
+      config:
+        - "\tmode tcp"
+        - "\tbind *:15672 ssl crt {{ ERIGONESD_SSL_FILE }}"
+        - "\tserver rabbitmq-mgmt 127.0.0.1:5672"
+    - name: redis
+      config:
+        - "\tmode tcp"
+        - "\tbind *:16379 ssl crt {{ ERIGONESD_SSL_FILE }}"
+        - "\tserver redis-mgmt 127.0.0.1:6379"
+    - name: zk_rest
+      config:
+        - "\tmode tcp"
+        - "\tbind *:12181"
+        - "\tserver zk-rest-cfgdb {{ cfgdb_ip }}:12181"
+  notify:
+    - reload haproxy
+
+- name: Configure firewall for admin services
+  iptables:
+    action: insert
+    chain: INPUT
+    ctstate: NEW
+    in_interface: eth0
+    protocol: tcp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+  with_items:
+    - 15672
+    - 16379
+    - 12181
+  notify:
+    - iptables-save
+

--- a/ans/upgrade/node/v3.0.0/main.sh
+++ b/ans/upgrade/node/v3.0.0/main.sh
@@ -14,10 +14,88 @@ SRC_CUSTOM_ETC="${VERSION_DIR}/files/custom-etc"
 mkdir -p "${CUSTOM_ETC}"
 
 for srcdir in "${SRC_CUSTOM_ETC}"/*; do
-	dirname="$(basename "${dir}")"
+	dirname="$(basename "${srcdir}")"
 	if [[ ! -e "${CUSTOM_ETC}/${dirname}" ]]; then
 		echo "+ Placing ${dirname} into ${CUSTOM_ETC}"
 		cp -a "${srcdir}" "${CUSTOM_ETC}"
 	fi
 done
 
+#
+# https://github.com/erigones/esdc-factory/issues/102
+#
+OPENSSL="/opt/local/bin/openssl"
+OPENSSL_CERTS="/opt/local/etc/openssl/certs"
+SVC_CERT_FILE_NAME="dc-erigonesd.pem"
+SVC_CERT_FILE_TMP="/tmp/${SVC_CERT_FILE_NAME}.$$"
+SVC_CERT_FILE="${CUSTOM_ETC}/${SVC_CERT_FILE_NAME}"  # Uses CUSTOM_ETC set above
+CTLSH="${ERIGONES_HOME}/bin/ctl.sh"
+ERIGONESD_CONFIG="${ERIGONES_HOME}/core/celery/local_config.py"
+ERIGONESD_CONFIG_BKP="${ERIGONESD_CONFIG}.$$.bkp"
+
+if [[ -f "${SVC_CERT_FILE}" ]] && "${ERIGONES_HOME}/bin/query_cfgdb" get /esdc/settings/dc/datacenter_name > /dev/null; then
+	echo "+ SSL certificate for internal services is already configured"
+else
+	# Fetch SSL certificate from cfgdb and save it to a temporary location
+	if ! "${ERIGONES_HOME}/bin/query_cfgdb" --legacy get /esdc/settings/security/services_ssl_cert > "${SVC_CERT_FILE_TMP}"; then
+		echo "ERROR: SSL certificate for internal services not found" 1>&2
+		exit 31
+	fi
+
+	# Check SSL certificate
+	if ! grep -q "\-END CERTIFICATE\-" "${SVC_CERT_FILE_TMP}"; then
+		echo "ERROR: Invalid SSL certificate for internal services" 1>&2
+		exit 32
+	fi
+
+	# Install SSL certificate to a predetermined location
+	echo "+ Installing SSL certificate for Danube Cloud services"
+	mv "${SVC_CERT_FILE_TMP}" "${SVC_CERT_FILE}"
+
+	# Make the esdc SSL certificate available for other clients
+	(
+	cd ${OPENSSL_CERTS}
+	ln -s "${SVC_CERT_FILE}" "${SVC_CERT_FILE_NAME}" || true
+	ln -s "${SVC_CERT_FILE_NAME}" "$("${OPENSSL}" x509 -hash -noout -in "${SVC_CERT_FILE}").0" || true
+	)
+
+	# Test SSL connection to ZK REST
+	if ! "${ERIGONES_HOME}/bin/query_cfgdb" get /esdc/settings/dc/datacenter_name > /dev/null; then
+		echo "ERROR: SSL connection to cfgdb has failed"
+		exit 33
+	fi
+fi
+
+if grep -q "^BROKER_USE_SSL" "${ERIGONESD_CONFIG}"; then
+	echo "+ erigonesd is already configured to connect via SSL"
+	exit 0
+fi
+
+# For the next operation we need to patch celery in our virtualenv
+echo "+ Patching packages in virtualenv"
+"${CTLSH}" patch_envs > /dev/null
+
+# Create backup of erigonesd configuration (local_config.py)
+cp -a "${ERIGONESD_CONFIG}" "${ERIGONESD_CONFIG_BKP}"
+
+# Something has failed -> restore backup (trap to ERR does not work)
+trap '[[ "$?" -ne 0 ]] && mv "${ERIGONESD_CONFIG_BKP}" "${ERIGONESD_CONFIG}"' EXIT
+
+# Configure SSL connection to rabbitmq and redis
+echo "+ Configuring erigonesd to connect via SSL"
+sed -i '' -e 's|:5672/|:15672/|' -e 's|:6379/|:16379/|' "${ERIGONESD_CONFIG}"
+cat >> "${ERIGONESD_CONFIG}" << EOF
+
+import ssl
+
+BROKER_USE_SSL = { 'cert_reqs': ssl.CERT_REQUIRED, 'ca_certs': '${SVC_CERT_FILE}' }
+REDIS_BACKEND_USE_SSL = { 'ssl_cert_reqs': ssl.CERT_REQUIRED, 'ssl_ca_certs': '${SVC_CERT_FILE}' }
+EOF
+
+# Test SSL connection to RabbitMQ and Redis
+if "${CTLSH}" service_check --node; then
+	rm -f "${ERIGONESD_CONFIG_BKP}"  # we good -> remove backup
+else
+	echo "ERROR: SSL connection to mgmt has failed"
+	exit 34
+fi

--- a/core/management/commands/service_check.py
+++ b/core/management/commands/service_check.py
@@ -1,0 +1,72 @@
+from ._base import DanubeCloudCommand, CommandOption, CommandError
+
+
+class Command(DanubeCloudCommand):
+    help = 'Check connection to internal/admin services.'
+    options = (
+        CommandOption('-q', '--que', '--node', action='store_true', dest='que_only', default=False,
+                      help='Check only services related to erigonesd on a compute node.'),
+    )
+
+    def _ok(self, ssl_on):
+        if ssl_on:
+            return self.colors.green('OK') + ' (SSL)'
+        else:
+            return self.colors.yellow('OK') + ' (no SSL)'
+
+    def _failed(self):
+        return self.colors.red('FAILED')
+
+    def check_rabbitmq(self):
+        from que.erigonesd import cq
+        con = cq.broker_connection()
+
+        try:
+            con.connect().send_heartbeat()
+        except Exception as exc:
+            self.display('RabbitMQ connection [{}]: {} ({})'.format(con.as_uri(), self._failed(), exc))
+            return False
+        else:
+            self.display('RabbitMQ connection [{}]: {}'.format(con.as_uri(), self._ok(con.ssl)))
+            return True
+
+    def check_redis(self):
+        from que.erigonesd import cq
+        con = cq.backend
+
+        try:
+            con.client.ping()
+        except Exception as exc:
+            self.display('Redis connection [{}]: {} ({})'.format(con.as_uri(), self._failed(), exc))
+            return False
+        else:
+            ssl = 'SSLConnection' in repr(con.client)
+            self.display('Redis connection [{}]: {}'.format(con.as_uri(), self._ok(ssl)))
+            return True
+
+    def check_db(self):
+        from django.db import connections
+        res = []
+
+        for db_name in connections:
+            con = connections[db_name]
+
+            try:
+                con.connect()
+            except Exception as exc:
+                self.display('Database "{}" connection: {} ({})'.format(db_name, self._failed(), exc))
+                res.append(False)
+            else:
+                self.display('Database "{}" connection [{}]: {}'.format(db_name, con.connection.dsn, self._ok(False)))
+                res.append(True)
+
+        return res
+
+    def handle(self, que_only=False, **options):
+        result = [self.check_redis(), self.check_rabbitmq()]
+
+        if not que_only:
+            result.extend(self.check_db())
+
+        if not all(result):
+            raise CommandError('Test connection to some services has failed')


### PR DESCRIPTION
Related to erigones/esdc-factory#102 and erigones/esdc-factory#108

- Added ctl.sh service_check command for checking connection to redis, rabbitmq, postgres/pgbouncer
- Added mgmt upgrade script, which generates new SSL key/certs and configures SSL service ports on haproxy
- Added cfgdb upgrade script, which enables SSL ZK REST service and stores new SSL certificate in ZooKeeper + fixes local query_cfgdb (https://github.com/erigones/esdc-factory/pull/108)
- Added node upgrade script, which enables SSL on erigonesd <-> mgmt (rabbitmq/redis)
  
  
  