### PR TITLE
Fixed potential race condition for incoming VM status change events

### DIFF
--- a/api/decorators.py
+++ b/api/decorators.py
@@ -313,7 +313,8 @@ def catch_api_exception(fun):
     return wrap
 
 
-def lock(timeout=settings.API_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for_release=False, bound=False):
+def lock(timeout=settings.API_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for_release=False, bound=False,
+         base_name=None):
     """
     Ensure that the decorated function does not run in parallel with the same function and arguments.
     """
@@ -325,7 +326,11 @@ def lock(timeout=settings.API_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for
             else:
                 params = args
 
-            fun_name = fun.__name__
+            if base_name:
+                fun_name = base_name
+            else:
+                fun_name = fun.__name__
+
             lock_keys = [fun_name]
             lock_keys.extend(str(params[i]) for i in key_args)
             lock_keys.extend(str(kwargs[i]) for i in key_kwargs)

--- a/api/task/utils.py
+++ b/api/task/utils.py
@@ -295,7 +295,8 @@ def callback(log_exception=True, update_user_tasks=True, check_parent_status=Tru
     return wrap
 
 
-def mgmt_lock(timeout=MGMT_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for_release=False, bound_task=False):
+def mgmt_lock(timeout=MGMT_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for_release=False, bound_task=False,
+              base_name=None):
     """
     Decorator for runtime task locks.
     This means that task will run, but will wait in a loop until it acquires a lock or will fail if timeout is reached.
@@ -308,8 +309,12 @@ def mgmt_lock(timeout=MGMT_LOCK_TIMEOUT, key_args=(), key_kwargs=(), wait_for_re
             else:
                 params = args
 
+            if base_name:
+                task_name = base_name
+            else:
+                task_name = fun.__name__
+
             task_id = params[0]
-            task_name = fun.__name__
             lock_keys = [task_name]
             lock_keys.extend(str(params[i]) for i in key_args)
             lock_keys.extend(str(kwargs[i]) for i in key_kwargs)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -47,6 +47,7 @@ Bugs
 - Fixed emergency cleanup for cancelled or deleted VM migration task - `#318 <https://github.com/erigones/esdc-ce/issues/318>`__
 - Fixed SSL cert update (restart haproxy after SSL cert change) - `#322 <https://github.com/erigones/esdc-ce/issues/322>`__
 - Fixed stale task info after image creation from snapshot - `#334 <https://github.com/erigones/esdc-ce/issues/334>`__
+- Fixed potential race condition when processing incoming VM status events - `#358 <https://github.com/erigones/esdc-ce/issues/358>`__
 
 
 2.6.7


### PR DESCRIPTION
In some situations the event detector on nodes can emit tightly
consecutive VM status change events. If this happens there is a
potential that the second event will be ignored leaving the VM in a
different state in DB vs node. This can happen when a zone is restarted
and the stop/start events are sent in a quick succession.

This change adds a lock to the _vm_status_check helper function which
will ensure that the events are process in serial order.