### PR TITLE
Fixed pip uninstall by setting TMPDIR to the same FS as erigones/envs

### DIFF
--- a/bin/ctl.sh
+++ b/bin/ctl.sh
@@ -54,6 +54,20 @@ set_django_settings() {
 	export DJANGO_SETTINGS_MODULE
 }
 
+update_env() {
+	export PYTHONUNBUFFERED="true"
+
+	case "${1}" in
+		pip_*)
+			# When uninstalling or upgrading Python packages with symlinks our version of
+			# Python/pip has a bug that causes the uninstall to fail in situations where
+			# the default TMPDIR (/tmp) is located on a different filesystem than the virtualenv.
+			# To fix this, we set TMPDIR closer to our virtualenv for all pip_* commands.
+			export TMPDIR="${ERIGONES_HOME}/var"
+		;;
+	esac
+}
+
 case "${ACTION}" in
 	"clean_envs")
 		virtualenv --relocatable "${ENVS}"
@@ -67,7 +81,7 @@ case "${ACTION}" in
 	*)
 		activate_envs
 		set_django_settings "$1"
-		export PYTHONUNBUFFERED="true"
+		update_env "$1"
 		"${MANAGEPY}" "${@}"
 	;;
 esac

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,7 @@ Bugs
 - Fixed version sort during upgrades - `#398 <https://github.com/erigones/esdc-ce/issues/398>`__
 - Fixed source VM deletion after migration on new SmartOS platform - `#396 <https://github.com/erigones/esdc-ce/pull/386>`__
 - Fixed migration of VM containing delegated dataset with children - `#405 <https://github.com/erigones/esdc-ce/issues/405>`__
+- Fixed problem with upgrading Python packages - `#408 <https://github.com/erigones/esdc-ce/issues/408>`__
 
 
 3.0.0


### PR DESCRIPTION
Closes #408