### PR TITLE
Fix esmigrate with indestructible zoneroot

### DIFF
--- a/bin/esmigrate
+++ b/bin/esmigrate
@@ -1247,7 +1247,7 @@ recv_kvm_ram() {
 	else
 		echo "ERROR: Unexpected problem with destination VM: ${UUID_SRC}" 1>&2
 		# Debug info
-		_dest_host_cmd "${SED}" -ne '/^=== OUTPUT/,//p' "${zone_root_dst}/root/tmp/vm.log" 1>&2
+		_dest_host_cmd "${SED}" -ne '/^=== OUTPUT/,//p' "/${zone_root_dst}/root/tmp/vm.log" 1>&2
 		die ${ERR_VM_MEM_SENDRECV} "Failed to resume destination VM: ${UUID_SRC}"
 	fi
 }
@@ -1304,12 +1304,18 @@ destroy_snapshots_dst() {
 	fi
 }
 
-_delete_vm() {
+_remove_indestructible() {
 	local uuid="$1"
 
 	if _vm_property "${JSON_SRC}" "indestructible_zoneroot" &> /dev/null; then
 		_vm_remove_indestructible_property "${uuid}" &>/dev/null
 	fi
+}
+
+_delete_vm() {
+	local uuid="$1"
+
+	_remove_indestructible "${uuid}"
 
 	# we cannot use "vmadm destroy" because it refuses to destroy a detached VM
 	_zone_delete "${uuid}" > /dev/null
@@ -1329,14 +1335,16 @@ destroy_datasets_src() {
 	local ds_root
 	local ds_data
 
+	_remove_indestructible "${UUID_SRC}"
+
 	if live_migration && [[ -n "${DEST_HOST}" ]]; then
-		# we need to get src VM to detached state before datasets removal
-		# (apply delete only to remote migration)
+		# - apply delete only to remote migration
+		# - we need to get src VM to detached state before datasets removal
 		techo "Halting source VM"
 		_zone_halt "${UUID_SRC}"
 
 		# core dataset can be destroyed only after VM stop
-		set_vm_status_src
+		set_vm_status_src	# re-read VM state
 		destroy_core_dataset
 
 		techo "Detaching source VM"

--- a/bin/esmigrate
+++ b/bin/esmigrate
@@ -1308,6 +1308,7 @@ _remove_indestructible() {
 	local uuid="$1"
 
 	if _vm_property "${JSON_SRC}" "indestructible_zoneroot" &> /dev/null; then
+		techo "Removing indestructible properties from VM datasets"
 		_vm_remove_indestructible_property "${uuid}" &>/dev/null
 	fi
 }

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,18 +18,19 @@ Features
 - Renamed FS for delegated dataset in the GUI - `#389 <https://github.com/erigones/esdc-ce/issues/389>`__
 - Changed value of VM's default PTR record to be its hostname - `#390 <https://github.com/erigones/esdc-ce/issues/390>`__
 - Add `hostname` property into VM's metadata implicitly - `#401 <https://github.com/erigones/esdc-ce/issues/401>`__
+- Added script for manually cleaning up resources after failed VM migration - `#403 <https://github.com/erigones/esdc-ce/pull/403>`__
 
 Bugs
 ----
 
 - Fixed core dataset re-creation during rollback after failed migration - `#386 <https://github.com/erigones/esdc-ce/pull/386>`__
 - Fixed node MAC address map in esdc-overlay command - `#404 <https://github.com/erigones/esdc-ce/pull/404>`__
-- Added script for manually cleaning up resources after failed VM migration - `#403 <https://github.com/erigones/esdc-ce/pull/403>`__
 - Fixed version sort during upgrades - `#398 <https://github.com/erigones/esdc-ce/issues/398>`__
 - Fixed source VM deletion after migration on new SmartOS platform - `#396 <https://github.com/erigones/esdc-ce/pull/386>`__
 - Fixed migration of VM containing delegated dataset with children - `#405 <https://github.com/erigones/esdc-ce/issues/405>`__
 - Fixed problem with upgrading Python packages - `#408 <https://github.com/erigones/esdc-ce/issues/408>`__
 - Fixed failure when displaying comparative VM graphs on compute node - `#395 <https://github.com/erigones/esdc-ce/issues/395>`__
+- Fixed printing qemu error log when destination VM fails to start - `#422 <https://github.com/erigones/esdc-ce/pull/422>`__
 
 
 3.0.0


### PR DESCRIPTION
* Fixes the regression in new way of destroying source VM datasets
* Fixes printing qemu error log when destination VM fails to start