### PR TITLE
fix updating KVM VM memory

### DIFF
--- a/vms/models/vm.py
+++ b/vms/models/vm.py
@@ -1753,7 +1753,7 @@ class Vm(_StatusModel, _JsonPickleModel, _OSType, _UserTasksModel):
             if max_swap < max_physical_memory:
                 max_swap = max_physical_memory
 
-            self.save_items(ram=value, max_physical_memory=max_physical_memory, max_swap=max_swap, save=False)
+            self.save_items(ram=value, max_physical_memory=max_physical_memory, max_swap=max_swap, max_locked_memory=max_physical_memory, save=False)
         else:
             self.save_items(max_physical_memory=value, max_swap=max_swap, save=False)
 


### PR DESCRIPTION
I've found the source of inconsistency. The reason is inconsistent setting of `max_locked_memory`.

Reference for similar future debugs:
https://github.com/joyent/triton/blob/master/docs/operator-guide/vminfod/troubleshooting.md