### PR TITLE
Allow overprovisioning of node memory

### DIFF
--- a/api/node/define/serializers.py
+++ b/api/node/define/serializers.py
@@ -40,7 +40,7 @@ class NodeDefineSerializer(s.InstanceSerializer):
     cpu = s.IntegerField(source='cpu_total', read_only=True)
     ram = s.IntegerField(source='ram_total', read_only=True)
     cpu_coef = s.DecimalField(min_value=0, max_digits=4, decimal_places=2)
-    ram_coef = s.DecimalField(min_value=0, max_value=5, max_digits=4, decimal_places=2)
+    ram_coef = s.DecimalField(min_value=0, max_digits=4, decimal_places=2)
     cpu_free = s.IntegerField(read_only=True)
     ram_free = s.IntegerField(read_only=True)
     ram_kvm_overhead = s.IntegerField(read_only=True)

--- a/api/node/define/serializers.py
+++ b/api/node/define/serializers.py
@@ -40,7 +40,7 @@ class NodeDefineSerializer(s.InstanceSerializer):
     cpu = s.IntegerField(source='cpu_total', read_only=True)
     ram = s.IntegerField(source='ram_total', read_only=True)
     cpu_coef = s.DecimalField(min_value=0, max_digits=4, decimal_places=2)
-    ram_coef = s.DecimalField(min_value=0, max_value=1, max_digits=4, decimal_places=2)
+    ram_coef = s.DecimalField(min_value=0, max_value=5, max_digits=4, decimal_places=2)
     cpu_free = s.IntegerField(read_only=True)
     ram_free = s.IntegerField(read_only=True)
     ram_kvm_overhead = s.IntegerField(read_only=True)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 #########
 
+4.1
+===
+Released on TBD
+
+Features
+--------
+
+- Allow overprovisioning of memory - `#441 <https://github.com/erigones/esdc-ce/pull/441>`__
+
+Bugs
+----
+
+- Fix `vminfod` timeout when updating KVM VM memory - `#439 <https://github.com/erigones/esdc-ce/issues/439>`__
+- Fix `refreservation` setting during `ha-prepare` - commit `5948089 <https://github.com/erigones/esdc-ce/commit/5948089d6752cb0f96d95586aa7f7974e07a270d>`__
+
 4.0
 ===
 Released on 2019-05-14

--- a/gui/node/forms.py
+++ b/gui/node/forms.py
@@ -95,7 +95,7 @@ class NodeForm(SerializerForm):
                                                                 'required': 'required'}))
     ram_coef = forms.DecimalField(label=_('RAM coefficient'), max_digits=4, decimal_places=2,
                                   help_text=_('Coefficient for calculating the maximum amount of memory '
-                                              'for virtual machines.'),
+                                              'for virtual machines. Keep it under 1 unless you really know what you are doing.'),
                                   widget=forms.TextInput(attrs={'class': 'input-transparent narrow',
                                                                 'required': 'required'}))
 


### PR DESCRIPTION
A simple and easy way of allowing the mem overprovisioning is increasing the limit of `ram_coef`. 
I've tested it and looks good.

The only thing we need to add is red warning in GUI near the `RAM coefficient` setting (visible only when set over `1`) saying something like 
Memory overprovisioning is dangerous and you should know what you are doing.