### PR TITLE
introduce requirements based on pkgsrc version

### DIFF
--- a/etc/requirements-both.txt-2016Q4
+++ b/etc/requirements-both.txt-2016Q4
@@ -17,8 +17,7 @@ simplejson==3.16.0
 frozendict==1.2
 requests==2.21.0
 esdc-api==2.0.1
-PyNaCl==1.4.0
-# paramiko >= 2.6.0 does not build on SmartOS
-paramiko==2.5.1
+# build of PyNaCl 1.3.0 is broken on SmartOS
+PyNaCl==1.2.1
 ansible==2.8.8
 Jinja2==2.10

--- a/etc/requirements-both.txt-2017Q4
+++ b/etc/requirements-both.txt-2017Q4
@@ -17,8 +17,7 @@ simplejson==3.16.0
 frozendict==1.2
 requests==2.21.0
 esdc-api==2.0.1
-PyNaCl==1.4.0
-# paramiko >= 2.6.0 does not build on SmartOS
-paramiko==2.5.1
+# build of PyNaCl 1.3.0 is broken on SmartOS
+PyNaCl==1.2.1
 ansible==2.8.8
 Jinja2==2.10

--- a/etc/requirements-both.txt-2018Q4
+++ b/etc/requirements-both.txt-2018Q4
@@ -17,8 +17,7 @@ simplejson==3.16.0
 frozendict==1.2
 requests==2.21.0
 esdc-api==2.0.1
-PyNaCl==1.4.0
-# paramiko >= 2.6.0 does not build on SmartOS
-paramiko==2.5.1
+# build of PyNaCl 1.3.0 is broken on SmartOS
+PyNaCl==1.2.1
 ansible==2.8.8
 Jinja2==2.10


### PR DESCRIPTION
We currently support multiple pkgsrc LTS releases and python requirements should follow this intention to prevent pip install/upgrade errors.