### PR TITLE
change default for MON_ZABBIX_TEMPLATES_VM_RESTRICT to False

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -521,7 +521,7 @@ MON_ZABBIX_TEMPLATES_VM = ()  # local, external
 MON_ZABBIX_TEMPLATES_VM_NIC = ()  # local, external
 MON_ZABBIX_TEMPLATES_VM_DISK = ()  # local, external
 MON_ZABBIX_TEMPLATES_VM_MAP_TO_TAGS = False  # local, external
-MON_ZABBIX_TEMPLATES_VM_RESTRICT = True  # local, external
+MON_ZABBIX_TEMPLATES_VM_RESTRICT = False  # local, external
 MON_ZABBIX_TEMPLATES_VM_ALLOWED = ()  # local, external
 
 MON_ZABBIX_HOST_VM_PORT = 10050  # local, external


### PR DESCRIPTION
Because this option is hidden deep in datacenter settings and it defaults to `True`, nobody is using Zabbix monitoring templates in VM settings (it throws forbidden error without explaining how to fix it).

I'm proposing a new default.

Downside of this change is that it affects also existing installations. But as there's not much harm done by changing it and (estimated) usage of this feature is very low, it should be ok.
We'll update changelog and release log with this info.