### PR TITLE
Support restoring a snapshot to other VM

### DIFF
--- a/gui/static/gui/css/form-elements.css
+++ b/gui/static/gui/css/form-elements.css
@@ -1007,6 +1007,11 @@ button.button.mini {
   box-shadow: inset 0px 0px 5px rgba(0, 0, 0, 0.5), 0px 1px 0px transparent;
 }
 
+.button-2nd-left {
+  margin-left: 5px;
+  float: left;
+}
+
 /* line 451, ../scss/form-elements.scss */
 .ui-datepicker {
   width: 210px;

--- a/gui/templates/gui/vm/snapshot.html
+++ b/gui/templates/gui/vm/snapshot.html
@@ -92,6 +92,7 @@
       {% if can_image %}
       <span class="pull-left"><a href="#" id="image_snapshot_link" class="btn btn-small btn-inverse no-ajax obj_add" data-prefix="img">{% trans "Create Image" %}</a></span>
       {% endif %}
+      <span class="button-2nd-left"><a href="#" id="snapshot_to_vm_link" class="btn btn-small btn-inverse no-ajax obj_add" data-prefix="img">{% trans "To other server..." %}</a></span>
       <a class="vm_modal_no button blue no-ajax" data-dismiss="modal">{% trans "Cancel" %}</a>
       <a class="vm_modal_yes_force button gold no-ajax" data-confirm="{% trans "Are you sure that you want to rollback the snapshot?" %}">{% trans "Rollback snapshot" %}</a>
       <a class="vm_modal_yes button red no-ajax" data-confirm="{% trans "Are you sure that you want to delete the snapshot?" %}">{% trans "Delete snapshot" %}</a>
@@ -188,6 +189,8 @@
   </div>
 </div>
 {% endif %}
+
+{% include "gui/vm/snapshot_to_vm_modal.html" %}
 
 <div class="container-fluid">
 

--- a/gui/templates/gui/vm/snapshot_list.html
+++ b/gui/templates/gui/vm/snapshot_list.html
@@ -22,7 +22,7 @@
   </thead>
   <tbody id="vm_snaplist_{{ vm.hostname }}">
     {% for snap in snapshots %}{% with disk_id=snap.array_disk_id snap_id=snap.snapid %}
-    <tr{% if snap_id == last_snapid %} class="info"{% endif %} data-disk_id="{{ disk_id }}" data-snapname="{{ snap.name }}" data-status="{{ snap.status }}" data-hostname="" data-type="">
+    <tr {% if snap_id == last_snapid %} class="info"{% endif %} data-disk_id="{{ disk_id }}" data-snapname="{{ snap.name }}" data-status="{{ snap.status }}" data-hostname="" data-type="" data-disk_size="{{ snap.disk_size }}">
       <td class="top chbox hidden-phone-small">
         <div class="input">
           <input type="checkbox" class="normal-check" id="id_{{ snap_id }}"{% if snap.locked %} disabled="disabled" readonly="true"{% endif %} />

--- a/gui/templates/gui/vm/snapshot_to_vm_modal.html
+++ b/gui/templates/gui/vm/snapshot_to_vm_modal.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+<div id="vm_snapshot_restore_to_vm_modal" class="black-box modal hide fade vm_modal">
+  <div class="modal-head tab-header">
+    <button type="button" class="close" data-dismiss="modal">&times;</button>
+    <span><i class="icon-warning-sign"></i> {% trans "Restore Snapshot to Other Server's Disk" %}</span>
+  </div>
+  <div class="modal-body separator">
+    <div class="alert alert-error modal_error hide"><i class="icon-warning-sign"></i> <span></span></div>
+    <div class="vm_modal_text modal-text-header">
+        {% trans "Source Hostname" %}: {% if vm %}{{ vm.hostname }}{% else %}__hostname__{% endif %}<br>
+        {% trans "Backup name: <strong>__name__</strong><br>Disk ID: <strong>__disk_id__</strong> (__disk_size__ MB)" %}
+    </div>
+    <form id="vm_backup_restore_form" class="form-horizontal">
+      <div class="vm_modal_force_text">{% trans "This will copy your snapshot data to disk of another server. Target disk must have the same size as source snapshot. <strong>All data on the target disk (including all existing snapshots) will be lost!</strong>" %}
+      </div>
+      <div class="vm_modal_force_text">
+        <span class="vm_modal_force_force">{% trans "Do you want to <strong>delete existing data on target disk</strong> and restore data from this snapshot?" %} <input type="checkbox" id="vm_snapshot_to_vm_force" class="big-check" /></span>
+      </div>
+      <div class="vm_modal_force_text">
+        {% include "gui/form_field.html" with field=bkpform_restore.target_hostname %}
+        {% include "gui/form_field.html" with field=bkpform_restore.target_disk_id %}
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <div class="inner-well">
+      <a class="vm_modal_no button blue no-ajax" data-dismiss="modal">{% trans "Cancel" %}</a>
+      <a class="vm_modal_snap2vm_yes button gold no-ajax" data-confirm="{% trans "Are you sure you want to restore the snapshot?" %}">{% trans "Restore snapshot" %}</a>
+    </div>
+  </div>
+</div>

--- a/gui/vm/views.py
+++ b/gui/vm/views.py
@@ -160,6 +160,7 @@ def snapshot(request, hostname):
         context['snapdeform_update'] = UpdateSnapshotDefineForm(request, vm)
         context['snapdeform_create'] = CreateSnapshotDefineForm(request, vm, prefix='snapdef_create',
                                                                 initial={'disk_id': 1, 'active': True})
+        context['bkpform_restore'] = RestoreBackupForm(vms)
 
     if context['can_image']:
         context['imgform'] = SnapshotImageForm(vm, request, None, prefix='img', initial={'owner': request.user.username,


### PR DESCRIPTION
Related to #524 

Adds functionality that allows user to restore any snapshot to other VM. 

It is effectively a way of cloning a running VM (create snapshot, create new VM with the same disk size, restore the snapshot to this new VM).

This is a preferred way of converting `KVM` machines to `bhyve`.

Please note that `bhyve` brand does not have integrated dhcp server as `KVM` does. Thus before conversion you need to set static IP inside a VM (or configure `cloud-init` with `SmartOS` datasource).