### PR TITLE
Allow external axfr

### DIFF
--- a/ans/upgrade/dns/v4.5/files/disable_public_axfr.py
+++ b/ans/upgrade/dns/v4.5/files/disable_public_axfr.py
@@ -1,0 +1,5 @@
+from pdns.models.pdns_config import PdnsCfg
+if not PdnsCfg.objects.filter(key='allow-axfr-ips'):
+    # add settings only if it doesn't exist to prevent overwriting custom values
+    cf = PdnsCfg(key='allow-axfr-ips', val='')
+    cf.save()

--- a/ans/upgrade/dns/v4.5/main.yml
+++ b/ans/upgrade/dns/v4.5/main.yml
@@ -12,4 +12,5 @@
 - name: Disable public AXFR
   local_action:
     module: shell
-    args: "{{ erigones_home }}/bin/ctl.sh" run_raw_py "{{ current_task_dir }}/files/disable_public_axfr.py"
+    args: "{{ erigones_home }}/bin/ctl.sh run_raw_py {{ current_task_dir }}/files/disable_public_axfr.py"
+

--- a/ans/upgrade/dns/v4.5/main.yml
+++ b/ans/upgrade/dns/v4.5/main.yml
@@ -1,0 +1,15 @@
+---
+# https://github.com/erigones/esdc-ce/issues/550
+# Allow sending zone notify to slaves
+- name: Change master value in pdns.conf
+  lineinfile:
+    path: /opt/local/etc/pdns.conf
+    regexp: '^#?master=.*'
+    line: 'master=yes'
+# pdns service reload is not needed because we're pushing a conf value to DB which will trigger reload
+
+# https://github.com/erigones/esdc-ce/issues/550
+- name: Disable public AXFR
+  local_action:
+    module: shell
+    args: "{{ erigones_home }}/bin/ctl.sh" run_raw_py "{{ current_task_dir }}/files/disable_public_axfr.py"

--- a/api/dns/domain/api_views.py
+++ b/api/dns/domain/api_views.py
@@ -4,15 +4,15 @@ from django.utils.translation import ugettext_lazy as _
 
 from api.status import HTTP_201_CREATED
 from api.api_views import APIView
-from api.exceptions import ExpectationFailed
+from api.exceptions import ExpectationFailed, InvalidInput
 from api.utils.views import call_api_view
 from api.task.response import SuccessTaskResponse, FailureTaskResponse
 from api.dns.domain.utils import get_domain, get_domains
-from api.dns.domain.serializers import DomainSerializer, ExtendedDomainSerializer
+from api.dns.domain.serializers import DomainSerializer, ExtendedDomainSerializer, TsigKeySerializer
 from api.dns.messages import LOG_DOMAIN_CREATE, LOG_DOMAIN_UPDATE, LOG_DOMAIN_DELETE
 from api.dc.utils import attach_dc_virt_object
 from api.dc.messages import LOG_DOMAIN_ATTACH
-from pdns.models import Record
+from pdns.models import Record, TsigKey
 from vms.models import Dc, DefaultDc
 
 logger = getLogger(__name__)
@@ -44,12 +44,17 @@ class DomainView(APIView):
             if self.full or self.extended:
                 if self.domain:
                     res = self.ser_class(self.request, self.domain, many=True).data
+                    if self.extended:
+                        # add tsig_keys parameter from different model
+                        res.update({'tsig_keys': [key.to_str() for key in TsigKey.get_linked_axfr_keys(self.domain)]})
                 else:
                     res = []
             else:
                 res = list(self.domain.values_list('name', flat=True))
         else:
             res = self.ser_class(self.request, self.domain).data
+            if self.extended:
+                res.update({'tsig_keys': [key.to_str() for key in TsigKey.get_linked_axfr_keys(self.domain)]})
 
         return SuccessTaskResponse(self.request, res, dc_bound=False)
 
@@ -68,7 +73,23 @@ class DomainView(APIView):
         if not ser.is_valid():
             return FailureTaskResponse(request, ser.errors, obj=domain, dc_bound=False)
 
+        tsig_data = {}
+        # in case there will be more tsig_* parameters (but for now, there's only tsig_keys)
+        for key, val in self.data.items():
+            # remove tsig_* parameters from request data because they belong to other validator
+            if key.startswith('tsig_'):
+                self.data.pop(key)
+                tsig_data[key[5:]] = val    # e.g: tsig_keys -> keys
+
+        tsig_keys_new, tsig_serializers = self.process_tsig_keys(request, tsig_data)
+
+        # save default serializer
         ser.object.save()
+        # save tsig serializer(s)
+        [ser_tsig.object.save() for ser_tsig in tsig_serializers]
+        # link newly defined TSIG keys to this domain
+        [new_key.link_to_axfr_domain(domain) for new_key in tsig_keys_new]
+
         res = SuccessTaskResponse(request, ser.data, status=HTTP_201_CREATED, obj=domain, dc_bound=False,
                                   msg=LOG_DOMAIN_CREATE, detail_dict=ser.detail_dict())
 
@@ -100,10 +121,32 @@ class DomainView(APIView):
         domain = self.domain
         ser = DomainSerializer(request, domain, data=self.data, partial=True)
 
+        # validate the main Domain form before processing TSIG params
         if not ser.is_valid():
             return FailureTaskResponse(request, ser.errors, obj=domain, dc_bound=False)
 
+        tsig_data = {}
+        # in case there will be more tsig_* parameters (but for now, there's only tsig_keys)
+        for key, val in self.data.items():
+            # remove tsig_* parameters from request data because they belong to other validator
+            if key.startswith('tsig_'):
+                self.data.pop(key)
+                tsig_data[key[5:]] = val    # e.g: tsig_keys -> keys
+
+        tsig_keys_new, tsig_serializers = self.process_tsig_keys(request, tsig_data)
+
+        # save default serializer
         ser.object.save()
+        # save tsig serializer(s)
+        [ser_tsig.object.save() for ser_tsig in tsig_serializers]
+        # link newly defined TSIG keys to this domain
+        [new_key.link_to_axfr_domain(domain) for new_key in tsig_keys_new]
+
+        # unlink old TSIG keys that were defined for this domain but they were removed in this update
+        tsig_keys_names = [key.name for key in tsig_keys_new]
+        [linked_key.unlink_axfr_domain(domain) for linked_key in TsigKey.get_linked_axfr_keys(domain)
+         if linked_key.name not in tsig_keys_names]
+
         res = SuccessTaskResponse(request, ser.data, obj=domain, msg=LOG_DOMAIN_UPDATE, detail_dict=ser.detail_dict(),
                                   dc_bound=False)
 
@@ -140,6 +183,86 @@ class DomainView(APIView):
 
         owner = domain.owner
         obj = domain.log_list
+
+        # unlink TSIG keys that were defined for this domain
+        [linked_key.unlink_axfr_domain(domain) for linked_key in TsigKey.get_linked_axfr_keys(domain)]
+
         domain.delete()
 
         return SuccessTaskResponse(self.request, None, obj=obj, owner=owner, msg=LOG_DOMAIN_DELETE, dc_bound=False)
+
+    def process_tsig_keys(self, request, tsig_data):
+        """
+        :param request:
+        :param tsig_data: dict that contains 'keys' key with the str containing comma separated key definitions
+                (for key definition see TsigKey.parse_tsig_string())
+        :return:
+            On success:
+            arg1: new_keys - list of new keys that are not yet in database (link them to this domain on commit)
+            arg2: tsig_serializers - list of verified but not saved serializer classes \
+                    (call .save() over each on commit)
+            On error:
+            :raises InvalidInput()
+        """
+
+        # remove spaces, ignore empty values
+        try:
+            tsig_keys = tsig_data['keys'].replace(' ', '')
+            tsig_keys = [x for x in tsig_keys.split(',') if x]
+        except (KeyError, AttributeError):
+            # no tsig keys found
+            return [], []
+
+        tsig_serializers = []
+        tsig_keys_new = []
+        for tsig_key_str in tsig_keys:
+            tsig_key_new_tmp = TsigKey.parse_tsig_string(tsig_key_str)
+            if not tsig_key_new_tmp:
+                raise InvalidInput('Invalid TSIG key: "%s"' % tsig_key_str)
+
+            tsig_key_from_db = TsigKey.objects.filter(name=tsig_key_new_tmp.name)
+            if not tsig_key_from_db:
+                # key is not in DB. Create it.
+                tsig_key = tsig_key_new_tmp
+            else:
+                # Key(s) with such name is already present. Check if the signature is also the same.
+                # We assume that only one key with such name can be present in DB.
+                # If our assumption is wrong, PDNS would probably fail anyway.
+                tsig_key_from_db = tsig_key_from_db[0]
+                if tsig_key_from_db.secret != tsig_key_new_tmp.secret:
+                    linked_domains = tsig_key_from_db.get_linked_axfr_domains()
+                    if len(linked_domains) == 0:
+                        # this is probably DB inconsistency... we have a key but it's not used anywhere
+                        pass
+                    elif len(linked_domains) == 1 and linked_domains[0].id == self.domain.id:
+                        # only one domain has this TSIG key defined - the domain we're editing just now.
+                        # Therefore it's safe to edit the key.
+                        tsig_key_from_db.secret = tsig_key_new_tmp.secret
+                        pass
+                    else:
+                        raise InvalidInput('TSIG key with the same name "%s" and different secret is already used '
+                                           'for other domain. Please use other key name.' % tsig_key_new_tmp.name)
+
+                elif tsig_key_from_db.algorithm != tsig_key_new_tmp.algorithm:
+                    raise InvalidInput('TSIG key\'s "%s" algorithm ("%s") does not match the one already saved in '
+                                       'database ("%s")' % (tsig_key_new_tmp.name,
+                                                            tsig_key_new_tmp.algorithm,
+                                                            tsig_key_from_db.algorithm))
+                else:
+                    # the key is the same, we don't need to save it again
+                    tsig_keys_new += [tsig_key_from_db]     # but we need it in this list
+                    continue
+
+                tsig_key = tsig_key_from_db
+
+            ser_tsig = TsigKeySerializer(request, tsig_key, read_only=False, many=False, data=tsig_data)
+            if not ser_tsig.is_valid():
+                return FailureTaskResponse(request, ser_tsig.errors, obj=self.domain, dc_bound=False)
+
+            # custom validation
+            tsig_key.validate()
+
+            tsig_serializers += [ser_tsig]
+            tsig_keys_new += [tsig_key]
+
+        return tsig_keys_new, tsig_serializers

--- a/api/dns/domain/serializers.py
+++ b/api/dns/domain/serializers.py
@@ -1,8 +1,20 @@
 from api import serializers as s
-from pdns.models import Domain
+from pdns.models import Domain, TsigKey
 from pdns.validators import validate_dns_name
 from vms.models import Dc
 from gui.models import User
+
+
+class TsigKeySerializer(s.InstanceSerializer):
+    """
+    pdns.models.TsigKey
+    """
+    _model_ = TsigKey
+    _update_fields_ = ('name', 'algorithm', 'secret')
+
+    name = s.RegexField(r'^[A-Za-z0-9][A-Za-z0-9\._/-]*$', max_length=250, min_length=3, required=False)
+    algorithm = s.ChoiceField(choices=TsigKey.ALGORITHM, required=False)
+    secret = s.SafeCharField(max_length=250, required=False)
 
 
 class DomainSerializer(s.ConditionalDCBoundSerializer):

--- a/api/dns/domain/views.py
+++ b/api/dns/domain/views.py
@@ -74,10 +74,14 @@ def dns_domain(request, name, data=None):
         :arg data.owner: User that owns the domain (default: logged in user)
         :type data.owner: string
         :arg data.type: PowerDNS domain type which determines how records are replicated. One of MASTER, NATIVE. \
-When set to MASTER, PowerDNS will use DNS protocol messages to communicate changes with slaves. \
-When set to NATIVE, PowerDNS will use database replication between master DNS \
+When set to MASTER, PowerDNS will send NOTIFY messages after zone changes to all hosts specified in NS record for \
+given domain. When set to NATIVE, PowerDNS will use only internal database replication between master DNS \
 server and slave DNS servers. (default: MASTER)
         :type data.type: string
+        :arg data.tsig_keys: Comma separated list of TSIG keys that will be allowed to do zone transfer query for \
+this domain. Format: "key-type:key-name:secret,key-type:key-name2:secret2"; Example: "hmac-sha256:mykey:aabbcc..". \
+(default: empty)
+        :type data.tsig_keys: string
         :arg data.desc: Domain description
         :type data.desc: string
         :arg data.dc_bound: Whether the domain is bound to a datacenter (requires |SuperAdmin| permission) \
@@ -104,12 +108,16 @@ server and slave DNS servers. (default: MASTER)
         :arg data.access: Access type (1 - Public, 3 - Private)
         :type data.access: integer
         :arg data.type: PowerDNS domain type which determines how records are replicated. One of MASTER, NATIVE. \
-When set to MASTER, PowerDNS will use DNS protocol messages to communicate changes with slaves. \
-When set to NATIVE, PowerDNS will use database replication between master DNS \
-server and slave DNS servers.
+When set to MASTER, PowerDNS will send NOTIFY messages after zone changes to all hosts specified in NS record for \
+given domain. When set to NATIVE, PowerDNS will use only internal database replication between master DNS \
+server and slave DNS servers. (default: MASTER)
         :type data.type: string
         :arg data.owner: User that owns the domain
         :type data.owner: string
+        :arg data.tsig_keys: Comma separated list of TSIG keys that will be allowed to do zone transfer query for \
+this domain. Format: "key-type:key-name:secret,key-type:key-name2:secret2"; Example: "hmac-sha256:mykey:aabbcc..". \
+(default: empty)
+        :type data.tsig_keys: string
         :arg data.desc: Domain description
         :type data.desc: string
         :arg data.dc_bound: Whether the domain is bound to a datacenter (requires |SuperAdmin| permission)

--- a/bin/ctl.sh
+++ b/bin/ctl.sh
@@ -72,12 +72,7 @@ exec_py() {
 	local py_file="$1"
 	shift
 
-	if [[ ! -x "${py_file}" ]]; then
-		echo "ERROR: File not executable: '${py_file}'"
-		exit 2
-	fi
-
-	"${py_file}" "${@}"
+	python2 "${py_file}" "${@}"
 }
 
 case "${ACTION}" in

--- a/gui/dc/dns/forms.py
+++ b/gui/dc/dns/forms.py
@@ -63,6 +63,12 @@ class AdminDomainForm(SerializerForm):
                                          'between master DNS server and slave DNS servers.'))
     desc = forms.CharField(label=_('Description'), max_length=128, required=False,
                            widget=forms.TextInput(attrs={'class': 'input-transparent wide', 'required': ''}))
+    tsig_keys = forms.CharField(label=_('TSIG Key(s)'), max_length=1000, required=False,
+                                  widget=forms.TextInput(attrs={'class': 'input-transparent', 'required': ''}),
+                                  help_text=_('TSIG DNS keys for external zone transfers. Zone transfers to '
+                                              'external DNS slaves will only be allowed using this key. '
+                                              'For more info on how to generate the key see Danube Cloud docs.'
+                                              ))
 
     def __init__(self, request, domain, *args, **kwargs):
         super(AdminDomainForm, self).__init__(request, domain, *args, **kwargs)

--- a/gui/templates/gui/dc/domain_admin_form.html
+++ b/gui/templates/gui/dc/domain_admin_form.html
@@ -10,6 +10,7 @@
 {% include "gui/form_field.html" with field=form.owner %}
 {% include "gui/form_field.html" with field=form.access %}
 {% include "gui/form_field.html" with field=form.type %}
+{% include "gui/form_field.html" with field=form.tsig_keys %}
 {% include "gui/form_field.html" with field=form.desc %}
-
-<div class="advanced hide"></div>
+<div class="advanced hide">
+</div>

--- a/pdns/fixtures/init.json
+++ b/pdns/fixtures/init.json
@@ -41,7 +41,7 @@
         "domain": 1,
         "name": "local",
         "prio": 0,
-        "content": "ns1.local hostmaster.example.com 2013033100 28800 7200 604800 86400",
+        "content": "ns1.local hostmaster.example.com 100 28800 7200 604800 86400",
         "ttl": 3600,
         "change_date": 1406645299,
         "type": "SOA"
@@ -67,7 +67,7 @@
         "domain": 2,
         "name": "lan",
         "prio": 0,
-        "content": "ns1.local hostmaster.default.com 2013033100 28800 7200 604800 86400",
+        "content": "ns1.local hostmaster.default.com 100 28800 7200 604800 86400",
         "ttl": 86400,
         "change_date": 1406645122,
         "type": "SOA"
@@ -84,6 +84,15 @@
         "ttl": 86400,
         "change_date": 1406645114,
         "type": "NS"
+    }
+},
+{
+    "pk": 1,
+    "model": "pdns.PdnsCfg",
+    "fields": {
+        "key": "allow-axfr-ips",
+        "val": "",
+        "change_date": 1626112479
     }
 }
 ]

--- a/pdns/models/__init__.py
+++ b/pdns/models/__init__.py
@@ -10,6 +10,7 @@ from pdns.models.record import Domain
 from pdns.models.pdns_config import PdnsCfg
 from pdns.models.pdns_config import PdnsRecursorCfg
 from pdns.models.pdns_config import RecurseNetworks
+from pdns.models.domainmetadata import DomainMetadata, TsigKey
 
 post_save.connect(Domain.post_save_domain, sender=Domain, dispatch_uid='post_save_domain')
 post_save.connect(Record.post_save_record, sender=Record, dispatch_uid='post_save_record')

--- a/pdns/models/domain.py
+++ b/pdns/models/domain.py
@@ -5,6 +5,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from logging import getLogger
 
+from pdns.models.domainmetadata import TsigKey
+
 logger = getLogger(__name__)
 
 
@@ -181,6 +183,7 @@ class Domain(models.Model):
             'owner': self.owner.username,
             'desc': self.desc,
             'dc_bound': self.dc_bound_bool,
+            'tsig_keys': ','.join([x.to_str() for x in TsigKey.get_linked_axfr_keys(self)]),
         }
 
     #

--- a/pdns/models/domainmetadata.py
+++ b/pdns/models/domainmetadata.py
@@ -1,0 +1,189 @@
+import re
+from django.db import models
+from logging import getLogger
+
+from api.exceptions import InvalidInput
+
+logger = getLogger(__name__)
+
+
+class DomainMetadata(models.Model):
+    """
+    This table contains metadata for all domains.
+
+    CREATE TABLE public.domainmetadata (
+        id integer NOT NULL,
+        domain_id integer,
+        kind character varying(32),
+        content text
+    );
+    """
+    domain = models.ForeignKey('pdns.Domain', blank=True, null=True)
+    kind = models.CharField(max_length=32, blank=True, null=True)
+    content = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'domainmetadata'
+
+    def __unicode__(self):
+        return '(%s: %s=%s)' % (self.domain, self.kind, self.content)
+
+    def save(self, *args, **kwargs):
+        logger.info('Saving domainmetadata entry for domain "%s": "%s"="%s"',
+                    self.domain, self.kind, self.content)
+        return super(DomainMetadata, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        logger.info('Deleting domainmetadata entry for domain "%s": "%s"="%s"',
+                    self.domain, self.kind, self.content)
+        return super(DomainMetadata, self).delete(*args, **kwargs)
+
+    @property
+    def get_content(self):
+        return self.content
+
+
+class TsigKey(models.Model):
+    """
+    This table stores TSIG DNS keys used for AXFR. It is referenced by DomainMetadata model.
+
+    CREATE TABLE public.tsigkeys (
+        id integer NOT NULL,
+        name character varying(255),
+        algorithm character varying(50),
+        secret character varying(255),
+        CONSTRAINT c_lowercase_name CHECK (((name)::text = lower((name)::text)))
+    );
+
+    """
+
+    # ALGORITHM = (
+    #     (MD5, "hmac-md5"),
+    #     (SHA1, "hmac-sha1"),
+    #     (SHA224, "hmac-sha224"),
+    #     (SHA256, "hmac-sha256"),
+    #     (SHA384, "hmac-sha384"),
+    #     (SHA512, "hmac-sha512"),
+    # )
+    ALGORITHM = (
+        ('hmac-md5', 'hmac-md5'),
+        ('hmac-sha1', 'hmac-sha1'),
+        ('hmac-sha224', 'hmac-sha224'),
+        ('hmac-sha256', 'hmac-sha256'),
+        ('hmac-sha384', 'hmac-sha384'),
+        ('hmac-sha512', 'hmac-sha512'),
+    )
+    ALGORITHM_DEFAULT = 'hmac-sha256'
+    ALGORITHMS = [x[1] for x in ALGORITHM]
+
+    name = models.CharField(max_length=255, blank=True, null=True)
+    algorithm = models.CharField(max_length=50, blank=True, null=True, choices=ALGORITHM, default=ALGORITHM_DEFAULT)
+    secret = models.CharField(max_length=255, blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'tsigkeys'
+        unique_together = (('name', 'algorithm'),)
+
+    def validate(self):
+        logger.error('Matching name: ', self.name)
+        if not re.match('^[A-Za-z0-9\._/-]{1,250}$', self.name):
+            logger.error('Matching name 2x: ', self.name)
+            raise InvalidInput('Invalid TSIG name: "%s"' % self.name)
+        if len(self.secret) > 250:
+            raise InvalidInput('TSIG secret too long')
+        if self.algorithm not in self.ALGORITHMS:
+            raise InvalidInput('Invalid TSIG algorithm: "%s". Must be one of: %s' % (self.algorithm, self.ALGORITHMS))
+        return True
+
+    def __str__(self):
+        return '(%s:%s:%s)' % (self.algorithm, self.name, self.secret)
+
+    def __unicode__(self):
+        return self.__str__()
+
+    def to_str(self):
+        return '%s:%s:%s' % (self.algorithm, self.name, self.secret)
+
+    # def save(self, *args, **kwargs):
+    #     logger.info('Saving tsigkey entry "%s" with algoritm "%s" and content "%s"',
+    #                 self.name, self.algorithm, self.secret)
+    #     return super(TsigKey, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        for domain in self.get_linked_axfr_domains():
+            self.unlink_axfr_domain(domain)
+
+        logger.info('Deleting tsigkey entry "%s" with algoritm "%s" and content "%s"',
+                    self.name, self.algorithm, self.secret)
+        return super(TsigKey, self).delete(*args, **kwargs)
+
+    @staticmethod
+    def get_linked_axfr_keys(domain):
+        """
+        Returns list of TSIG keys set for specified domain.
+        :param domain: Domain object
+        :return: list of TsigKey objects
+        """
+        return [TsigKey.objects.get(name=key_name.content) for key_name in
+                DomainMetadata.objects.filter(kind='TSIG-ALLOW-AXFR', domain_id=domain.id)]
+
+    def get_linked_axfr_domains(self):
+        """
+        Returns list of domains which use this TSIG key.
+        :return: list of Domain objects
+        """
+        return [entry.domain for entry in DomainMetadata.objects.filter(kind='TSIG-ALLOW-AXFR', content=self.name)]
+
+    def link_to_axfr_domain(self, domain):
+        """
+        Sets TSIG-ALLOW-AXFR for domain.id to tsigkey.name.
+        :param domain: Domain object
+        :return: django exception on error, else nothing
+        """
+        try:
+            DomainMetadata.objects.get(kind='TSIG-ALLOW-AXFR', domain_id=domain.id, content=self.name)
+            # key already exists, do nothing
+            return
+
+        except DomainMetadata.DoesNotExist:
+            DomainMetadata(kind='TSIG-ALLOW-AXFR', domain_id=domain.id, content=self.name).save()
+
+    def unlink_axfr_domain(self, domain):
+        """
+        Removes entry TSIG-ALLOW-AXFR for domain.id pointing to self.name.
+        :param domain: Domain object
+        :return: django exception on error, else nothing
+        """
+        try:
+            link = DomainMetadata.objects.get(kind='TSIG-ALLOW-AXFR', domain_id=domain.id, content=self.name)
+            link.delete()
+            if len(self.get_linked_axfr_domains()) == 0:
+                # no domains use this key anymore... we can delete it
+                logger.info('The TSIG key "%s" is no longer in use. Deleting it.' % self.name)
+                self.delete()
+
+        except DomainMetadata.DoesNotExist:
+            # nothing to delete
+            return
+
+    @staticmethod
+    def parse_tsig_string(text):
+        """
+        Converts string to TsigKey object.
+        :param text: "algorithm:name:key" or "name:key" (default algorithm is TsigKey.ALGORITHM_DEFAULT)
+        :return: new TsigKey object or None on error
+        """
+        try:
+            key = text.split(':')
+            if len(key) == 2:
+                return TsigKey(algorithm=TsigKey.ALGORITHM_DEFAULT, name=key[0], secret=key[1])
+            elif len(key) == 1:
+                # this creates invalid TsigKey but the name can be filled in also later to make the object valid
+                return TsigKey(algorithm=TsigKey.ALGORITHM_DEFAULT, name='', secret=key[0])
+            else:
+                return TsigKey(algorithm=key[0], name=key[1], secret=key[2])
+        except IndexError:
+            # invalid TSIG string format
+            return None

--- a/pdns/models/record.py
+++ b/pdns/models/record.py
@@ -305,7 +305,10 @@ class Record(models.Model):
         try:
             soa_rec = cls.objects.get(type=cls.SOA, domain_id=instance.domain.id)
         except cls.DoesNotExist:
-            logger.warning('SOA record does not exist!')
+            logger.warning('SOA record does not exist! Not doing SOA increment.')
+            return
+        except Domain.DoesNotExist:
+            logger.info('increment_SOA_serial: Domain does not exist. Ignoring SOA increment.')
             return
 
         soa_rec_content = soa_rec.content.split()


### PR DESCRIPTION
Fixes #550 
Fixes #552 

This feature allows DNS zone transfers to external DNS slave servers. Domain has now new property (in GUI and API): `TSIG Key(s)` that are permitted to do AXFR/IXFR transfers. All other zone transfer requests are denied.

