### PR TITLE
[FIX] Security - useing Safeloader

### DIFF
--- a/bin/ha-prepare
+++ b/bin/ha-prepare
@@ -201,7 +201,7 @@ def save_conf():
 def load_conf():
     with open(ANSIBLE_CFG_FILE, 'r') as stream:
         try:
-            print(yaml.load(stream))
+            print(yaml.safe_load(stream))
         except yaml.YAMLError as exc:
             print(exc)
 


### PR DESCRIPTION
using Safe_load instead of yaml.load to avoid security risks

here is a example proof of concept for arbitrary code execution using yaml.load() : 

![poc](https://user-images.githubusercontent.com/36979660/136097615-8ff2d4c6-3830-42ea-9004-7ef80b61682a.png)



**Hacktoberfest**