### PR TITLE
Verify image bootrom requirement before deploy

### DIFF
--- a/api/vm/base/vm_manage.py
+++ b/api/vm/base/vm_manage.py
@@ -295,6 +295,14 @@ class VmManage(APIView):
         if not vm.is_bootable():
             raise PreconditionRequired('VM has no bootable disk')
 
+        # check bootrom compatibility for selected image (otherwise the deployment will fail on vmadm error)
+        if vm.is_hvm() and vm.bootrom:
+            img = vm.json_get_first_disk_image()
+            if img and 'bootrom' in img.requirements:
+                if vm.bootrom != img.requirements['bootrom']:
+                    raise PreconditionRequired('Incompatible BOOTROM settings for selected disk image (UEFI vs BIOS). \
+                    Please check advanced settings of this VM.')
+
         if vm.tasks:
             raise VmHasPendingTasks
 


### PR DESCRIPTION
When image requirements contain `{'bootrom': 'uefi'}`, `vmadm create` call fails if the source json contains different value. Therefore we'll check this requirements before deploying the VM and issue warning when the values don't match.